### PR TITLE
Fix mobile sidebar toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,13 +283,13 @@
                     setActiveLink(link);
                     showSection(id);
                     history.replaceState(null, "", `#${id}`);
-                    if (window.innerWidth <= 768) sidebar.classList.add("closed");
+                    if (window.innerWidth <= 768) sidebar.classList.remove("open");
                 });
             });
 
             // hamburger
             menuBtn.addEventListener("click", () => {
-                sidebar.classList.toggle("closed");
+                sidebar.classList.toggle("open");
             });
         });
     </script>

--- a/styles.css
+++ b/styles.css
@@ -80,10 +80,6 @@ body {
     transition: transform 0.3s ease;
 }
 
-#sidebar.closed {
-    transform: translateX(-100%);
-}
-
 nav ul {
     list-style: none;
     margin: 0;


### PR DESCRIPTION
## Summary
- align sidebar toggle with CSS by using the `open` class
- remove obsolete `closed` sidebar style

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a2effcd8832c992e7dc9bd5118c3