### PR TITLE
Style metadata list with gray background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -128,12 +128,19 @@ h2 {
 .meta {
     list-style: none;
     margin: 0 0 1.5rem 0;
-    padding: 0;
+    padding: 1rem;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 0.5rem 1rem;
     font-size: 0.9rem;
     color: #555;
+    background: #f0f0f0;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.meta li {
+    list-style: none;
 }
 
 .meta .icon {


### PR DESCRIPTION
## Summary
- remove bullets from metadata list items
- add grey background and border around metadata block

## Testing
- `npm test` (fails: ENOENT package.json)

------
https://chatgpt.com/codex/tasks/task_e_6894b7566f88832bbe8888c266e39fbe