### PR TITLE
Fix footer layering and mobile grid

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -285,10 +285,19 @@ h2 {
         top: 0;
         width: var(--sidebar-width);
         transform: translateX(-100%);
+        z-index: 999;
     }
 
     #sidebar.open {
         transform: translateX(0);
+    }
+
+    main {
+        grid-column: 1;
+    }
+
+    footer {
+        grid-column: 1;
     }
 
     .hamburger {


### PR DESCRIPTION
## Summary
- ensure mobile sidebar overlays main content and footer
- align main content and footer to single-column grid on small screens

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68959edddae8832ca83cad819555983d