### PR TITLE
Hide contact card for non-admin users

### DIFF
--- a/script.js
+++ b/script.js
@@ -115,27 +115,32 @@ const isAdmin = new URLSearchParams(window.location.search).get('admin') === 'tr
     .join('<br>');
 })();
 
-      const contactInfo = uc['Informace o zdroji a kontaktní osoba']
-  ? (() => {
-      const parts = uc['Informace o zdroji a kontaktní osoba'].split('\n').map(s => s.trim()).filter(Boolean);
-
-      if (parts.length === 0) return '-';
-
-      const linkPart = parts[parts.length - 1]; // poslední řádek = odkaz
-      const textPart = parts.slice(0, -1).join('<br />'); // vše před tím = text
-
-      const linkHtml = (linkPart.startsWith('http://') || linkPart.startsWith('https://'))
-        ? `<a href="${linkPart}" target="_blank" rel="noopener">${uc['Označení kontaktní osoby'] || linkPart}</a>`
-        : linkPart; // kdyby poslední řádek nebyl URL
-
-      return `${textPart}${textPart && linkHtml ? '<br />' : ''}${linkHtml}`;
-    })()
-        : '<p>-</p>';
- 
       html += '<div class="bottom-cards">';
       html += `<div class="card"><strong>Stav projektu</strong><span>${uc['Stav projektu'] || '-'}</span></div>`;
       html += `<div class="card"><strong>Zdroj</strong><span>${docLink}</span></div>`;
-      html += `<div class="card"><strong>Kontaktní osoba</strong><span>${contactInfo}</span></div>`;
+      if (isAdmin) {
+        const contactInfo = uc['Informace o zdroji a kontaktní osoba']
+          ? (() => {
+              const parts = uc['Informace o zdroji a kontaktní osoba']
+                .split('\\n')
+                .map((s) => s.trim())
+                .filter(Boolean);
+
+              if (parts.length === 0) return '-';
+
+              const linkPart = parts[parts.length - 1]; // poslední řádek = odkaz
+              const textPart = parts.slice(0, -1).join('<br />'); // vše před tím = text
+
+              const linkHtml =
+                linkPart.startsWith('http://') || linkPart.startsWith('https://')
+                  ? `<a href="${linkPart}" target="_blank" rel="noopener">${uc['Označení kontaktní osoby'] || linkPart}</a>`
+                  : linkPart; // kdyby poslední řádek nebyl URL
+
+              return `${textPart}${textPart && linkHtml ? '<br />' : ''}${linkHtml}`;
+            })()
+          : '<p>-</p>';
+        html += `<div class="card"><strong>Kontaktní osoba</strong><span>${contactInfo}</span></div>`;
+      }
       html += '</div>';
  
       section.innerHTML = html;


### PR DESCRIPTION
## Summary
- Hide the "Kontaktní osoba" card when the `admin` URL parameter is not true

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c59097344832c8456a06102413011