### PR TITLE
feat: add footer logo text

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,8 +18,12 @@ function initCommon() {
   const footerLogo = document.querySelector('.footer-logo');
   const logo = document.querySelector('.logo');
   if (footerLogo && logo) {
-    // Stejné logo v hlavičce i patičce
+    // Stejné logo v hlavičce i patičce doplněné o text jako na dia.gov.cz
     footerLogo.innerHTML = logo.innerHTML;
+    const logoText = document.createElement('span');
+    logoText.className = 'logo-text';
+    logoText.textContent = 'Digitální a informační agentura';
+    footerLogo.appendChild(logoText);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -125,6 +125,8 @@ footer .footer-block {
 footer .footer-logo {
     display: flex;
     justify-content: flex-start; /* zarovnání doleva */
+    align-items: center;
+    gap: 1rem;
     margin-bottom: 0.5rem;
 }
 
@@ -133,6 +135,12 @@ footer .footer-logo img {
     width: 200px;   /* šířka loga */
     height: 60px;   /* výška loga */
     object-fit: contain; /* zachování proporcí u obrázků */
+}
+
+footer .footer-logo .logo-text {
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: white;
 }
 
 footer a {


### PR DESCRIPTION
## Summary
- show "Digitální a informační agentura" text next to footer logo
- style footer logo area for horizontal layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c90463fb8832b8c1b3198ed16a894