### PR TITLE
Fix category popup to open on click and close on outside click

### DIFF
--- a/script.js
+++ b/script.js
@@ -186,8 +186,17 @@ const isAdmin = new URLSearchParams(window.location.search).get('admin') === 'tr
     const popupDesc = popup?.querySelector('p');
     const popupClose = popup?.querySelector('.popup-close');
     if (popup && popupTitle && popupDesc && popupClose) {
-      popupClose.addEventListener('click', () => {
+      const hidePopup = () => {
         popup.style.display = 'none';
+      };
+      popupClose.addEventListener('click', hidePopup);
+
+      // Zavření při kliknutí mimo obsah
+      popup.addEventListener('click', (e) => {
+        if (e.target === popup) hidePopup();
+      });
+      document.addEventListener('click', (e) => {
+        if (popup.style.display === 'flex' && !popup.contains(e.target)) hidePopup();
       });
 
       document.querySelectorAll('.category-link').forEach((link) => {
@@ -195,11 +204,11 @@ const isAdmin = new URLSearchParams(window.location.search).get('admin') === 'tr
         const desc = categoryDescriptions.get(cat);
         const showPopup = (e) => {
           e.preventDefault();
+          e.stopPropagation();
           popupTitle.textContent = cat;
           popupDesc.textContent = desc || '';
           popup.style.display = 'flex';
         };
-        link.addEventListener('mouseenter', showPopup);
         link.addEventListener('click', showPopup);
       });
     }


### PR DESCRIPTION
## Summary
- Show category information popup only after clicking the category link
- Allow closing popup by clicking outside or the close button

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689c91a539d0832c9de584d6210eb7bd