### PR TITLE
Enlarge info banner close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,11 @@
     </footer>
 
     <div id="info-banner" class="info-banner">
-        <button class="banner-close" aria-label="Zavřít banner">&times;</button>
+        <button class="banner-close" aria-label="Zavřít">
+            <svg class="banner-close-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M18.3 5.7a1 1 0 0 0-1.4-1.4L12 9.17 7.1 4.3a1 1 0 1 0-1.4 1.4L10.83 12l-5.13 5.1a1 1 0 0 0 1.4 1.4L12 14.83l4.9 4.87a1 1 0 0 0 1.4-1.4L13.17 12l5.13-5.1z" />
+            </svg>
+        </button>
         <p>
             Máte tip na inspirativní projekt s AI ve veřejném sektoru? Přidejte svůj příspěvek <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMnjLBUkiFR6cAExs28azQ6emrvqm1ptWcizBmWRx2Om3ejQ/viewform?usp=dialog">zde</a> a my jej rádi zařadíme do katalogu.
         </p>

--- a/script.js
+++ b/script.js
@@ -350,6 +350,11 @@ function initInfoBanner() {
   };
 
   bannerClose.addEventListener('click', hideBanner);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      hideBanner();
+    }
+  });
 }
 
 // Start po načtení DOMu

--- a/styles.css
+++ b/styles.css
@@ -47,13 +47,44 @@ body.single-column {
 
 .info-banner .banner-close {
     position: absolute;
-    top: 4px;
-    right: 4px;
-    background: none;
+    top: 8px;
+    right: 8px;
+    width: 44px;
+    height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: none;
-    color: #fff;
-    font-size: 1rem;
+    background: transparent;
     cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    color: #fff;
+}
+
+.info-banner .banner-close-icon {
+    width: 24px;
+    height: 24px;
+    color: #fff;
+}
+
+.info-banner .banner-close:hover .banner-close-icon,
+.info-banner .banner-close:focus .banner-close-icon,
+.info-banner .banner-close:active .banner-close-icon {
+    filter: brightness(0.9);
+    transform: scale(1.05);
+}
+
+.info-banner .banner-close:focus {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+}
+
+@media (max-width: 420px) {
+    .info-banner .banner-close {
+        top: 6px;
+        right: 6px;
+    }
 }
 
 /* ===== Top bar ===== */


### PR DESCRIPTION
## Summary
- make info banner close icon larger with 44×44px tap target and 24×24px SVG icon
- add hover/focus styles and accessible label
- allow closing banner with Escape key

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9872898c832b94968f82ffb3e4a0