### PR TITLE
Make close icons white

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -68,6 +68,10 @@ body.single-column {
     color: #fff;
 }
 
+.info-banner .banner-close-icon path {
+    fill: currentColor;
+}
+
 .info-banner .banner-close:hover .banner-close-icon,
 .info-banner .banner-close:focus .banner-close-icon,
 .info-banner .banner-close:active .banner-close-icon {
@@ -596,6 +600,7 @@ h3 {
     border: none;
     font-size: 1.5rem;
     cursor: pointer;
+    color: #fff;
 }
 
 .category-popup h3 {


### PR DESCRIPTION
## Summary
- Ensure banner close icon inherits its color to render white
- Set category popup close button text to white

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9a8a535c832b838fbd034e584e06