### PR TITLE
Fix popup close behavior and button colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
 
     <div id="ai-tip-popup" class="popup" role="dialog" aria-live="polite" aria-label="Tip na inspirativní projekt s AI" aria-hidden="true">
   <button class="popup-close" aria-label="Zavřít" type="button">
-    <svg viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
       <line x1="18" y1="6" x2="6" y2="18" />
       <line x1="6" y1="6" x2="18" y2="18" />
     </svg>

--- a/styles.css
+++ b/styles.css
@@ -39,6 +39,10 @@ body.single-column {
   z-index: 1000;
 }
 
+.popup[aria-hidden="true"] {
+  display: none;
+}
+
 .popup a {
   color: white;
   text-decoration: underline;
@@ -583,7 +587,7 @@ h3 {
     border: none;
     font-size: 1.5rem;
     cursor: pointer;
-    color: #fff;
+    color: #000;
 }
 
 .category-popup h3 {


### PR DESCRIPTION
## Summary
- Hide info banner when aria-hidden is set and ensure close button works
- Render info banner close icon in black
- Show category popup close button in black

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aaffc7d4832c90debe1b0444a814