### PR TITLE
fix: ensure AI tip popup close icon is white

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,10 @@ body.single-column {
   height: 20px;
 }
 
+#ai-tip-popup .popup-close svg {
+  stroke: #fff;
+}
+
 /* ===== Top bar ===== */
 .topbar {
     position: fixed;


### PR DESCRIPTION
## Summary
- style AI tip popup's close button SVG stroke to white

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aec90370832c82b5c3b80da3c6a2