### PR TITLE
Close mobile menu when clicking outside

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,6 +13,18 @@ function initCommon() {
     menuBtn.addEventListener('click', () => {
       sidebar.classList.toggle('open');
     });
+
+    // Zavření menu při kliknutí mimo něj na mobilu
+    document.addEventListener('click', (e) => {
+      if (
+        window.innerWidth <= 768 &&
+        sidebar.classList.contains('open') &&
+        !sidebar.contains(e.target) &&
+        !menuBtn.contains(e.target)
+      ) {
+        sidebar.classList.remove('open');
+      }
+    });
   }
 
   const footerLogo = document.querySelector('.footer-logo');


### PR DESCRIPTION
## Summary
- Close the mobile sidebar menu when clicking outside of it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b43ba4a8832ca7418cbc3f7930bf