### PR TITLE
Improve sidebar accessibility with ARIA attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 <body>
     <div class="topbar">
-        <button class="hamburger" id="menuBtn" aria-label="Menu">
+        <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="sidebar" aria-expanded="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                 stroke-linejoin="round">
                 <line x1="3" y1="12" x2="21" y2="12"></line>

--- a/podminky.html
+++ b/podminky.html
@@ -10,7 +10,7 @@
 
 <body>
     <div class="topbar">
-        <button class="hamburger" id="menuBtn" aria-label="Menu">
+        <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="sidebar" aria-expanded="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="3" y1="12" x2="21" y2="12"></line>
                 <line x1="3" y1="6" x2="21" y2="6"></line>

--- a/prohlaseni.html
+++ b/prohlaseni.html
@@ -10,7 +10,7 @@
 
 <body>
     <div class="topbar">
-        <button class="hamburger" id="menuBtn" aria-label="Menu">
+        <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="sidebar" aria-expanded="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <line x1="3" y1="12" x2="21" y2="12"></line>
                 <line x1="3" y1="6" x2="21" y2="6"></line>

--- a/script.js
+++ b/script.js
@@ -8,7 +8,14 @@ function initCommon() {
   const menuBtn = document.getElementById('menuBtn');
 
   if (sidebar && menuBtn) {
-    menuBtn.addEventListener('click', () => sidebar.classList.toggle('open'));
+    sidebar.setAttribute('aria-hidden', 'true');
+    menuBtn.setAttribute('aria-expanded', 'false');
+
+    menuBtn.addEventListener('click', () => {
+      const isOpen = sidebar.classList.toggle('open');
+      menuBtn.setAttribute('aria-expanded', String(isOpen));
+      sidebar.setAttribute('aria-hidden', String(!isOpen));
+    });
 
     document.addEventListener('click', (e) => {
       if (
@@ -18,6 +25,16 @@ function initCommon() {
         !menuBtn.contains(e.target)
       ) {
         sidebar.classList.remove('open');
+        menuBtn.setAttribute('aria-expanded', 'false');
+        sidebar.setAttribute('aria-hidden', 'true');
+      }
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && sidebar.classList.contains('open')) {
+        sidebar.classList.remove('open');
+        menuBtn.setAttribute('aria-expanded', 'false');
+        sidebar.setAttribute('aria-hidden', 'true');
       }
     });
   }


### PR DESCRIPTION
## Summary
- Add `aria-controls="sidebar"` and `aria-expanded="false"` to each page's menu button.
- Toggle `aria-expanded` on the menu button and `aria-hidden` on the sidebar when opened or closed.
- Close the sidebar via the Escape key with appropriate ARIA updates.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07176b9e8832bb335fc735c45cf61