### PR TITLE
Enhance accessibility with skip links and navigation labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 </head>
 
 <body>
+    <a href="#main" class="skip-link">Přeskočit na obsah</a>
     <div class="topbar">
         <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="sidebar" aria-expanded="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -27,11 +28,11 @@
     </div>
 
     <aside id="sidebar">
-        <nav>
+        <nav aria-label="Přehled use casů">
             <ul id="usecase-list"></ul>
         </nav>
     </aside>
-    <main></main>
+    <main id="main"></main>
 
     <footer>
   <div class="footer-container">

--- a/podminky.html
+++ b/podminky.html
@@ -9,6 +9,7 @@
 </head>
 
 <body>
+    <a href="#main" class="skip-link">Přeskočit na obsah</a>
     <div class="topbar">
         <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="sidebar" aria-expanded="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -113,8 +114,13 @@
         </div>
         <h1>Katalog využití AI ve veřejném sektoru</h1>
     </div>
+    <aside id="sidebar">
+        <nav aria-label="Přehled use casů">
+            <ul id="usecase-list"></ul>
+        </nav>
+    </aside>
 
-    <main>
+    <main id="main">
         <section class="active">
             <h2>Podmínky využití a ochrana osobních údajů</h2>
             <p>Tento katalog je provozován Digitální a informační agenturou (DIA). Obsah je poskytován pro informační účely a může být měněn bez předchozího upozornění.</p>

--- a/prohlaseni.html
+++ b/prohlaseni.html
@@ -9,6 +9,7 @@
 </head>
 
 <body>
+    <a href="#main" class="skip-link">Přeskočit na obsah</a>
     <div class="topbar">
         <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="sidebar" aria-expanded="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -113,8 +114,13 @@
         </div>
         <h1>Katalog využití AI ve veřejném sektoru</h1>
     </div>
+    <aside id="sidebar">
+        <nav aria-label="Přehled use casů">
+            <ul id="usecase-list"></ul>
+        </nav>
+    </aside>
 
-    <main>
+    <main id="main">
         <section class="active">
             <h2>Prohlášení o přístupnosti</h2>
             <p>Webové stránky <strong>egovai.dia.gov.cz</strong> byla navržena s ohledem na co možná nejvyšší uživatelský komfort, přehlednost a přístupnost. Digitální a informační agentura se zavazuje k zpřístupnění své internetové stránky v souladu se Zákonem č. 99/2019 Sb., o přístupnosti internetových stránek a mobilních aplikací a o změně Zákona č. 365/2000 Sb., o informačních systémech veřejné správy a o změně některých dalších zákonů, ve znění pozdějších předpisů, který provádí Směrnici Evropského parlamentu a Rady (EU) 2016/2102 ze dne 26. října 2016 o přístupnosti internetových stránek a mobilních aplikací.</p>

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,27 @@ body {
     min-height: 100vh;
 }
 
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.skip-link:focus {
+    left: 0;
+    top: 0;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    background: #fff;
+    color: var(--text);
+    padding: 1rem;
+    z-index: 1000;
+}
+
 body.single-column {
     display: block;
     min-height: 100vh;


### PR DESCRIPTION
## Summary
- add skip links on all pages and expose them only on focus
- label navigation as "Přehled use casů" for screen readers and mark main content with an id
## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0748efed8832bb19be04310774e65