### PR TITLE
Improve popup accessibility and focus handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,19 +85,18 @@
   </div>
 </footer>
 
-  <div id="ai-tip-popup" class="popup" aria-hidden="true">
+  <div id="ai-tip-popup" class="popup" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="ai-tip-title">
   <div class="popup-content">
     <button class="popup-close" aria-label="Close">&times;</button>
-    <p>Máte tip na inspirativní projekt s AI ve veřejném sektoru?
-    <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMnjLBUkiFR6cAExs28azQ6emrvqm1ptWcizBmWRx2Om3ejQ/viewform?usp=dialog" target="_blank" rel="noopener">Přidejte svůj příspěvek</a> a my jej rádi zařadíme do katalogu.
-</p>
+    <h3 id="ai-tip-title">Máte tip na inspirativní projekt s AI ve veřejném sektoru?</h3>
+    <p><a href="https://docs.google.com/forms/d/e/1FAIpQLSeMnjLBUkiFR6cAExs28azQ6emrvqm1ptWcizBmWRx2Om3ejQ/viewform?usp=dialog" target="_blank" rel="noopener">Přidejte svůj příspěvek</a> a my jej rádi zařadíme do katalogu.</p>
   </div>
 </div>
 
-<div id="category-popup" class="category-popup" aria-hidden="true" role="dialog">
+<div id="category-popup" class="category-popup" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="category-popup-title">
   <div class="popup-content">
     <button class="popup-close" aria-label="Zavřít">&times;</button>
-    <h3></h3>
+    <h3 id="category-popup-title"></h3>
     <p></p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- label popups as modal dialogs with `aria` attributes and headings
- manage focus for info banner open/close
- trap focus inside category popup and close on Escape

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b076eeb794832b9f8d7ac77847058a