### PR TITLE
Add aria-hidden to navigation arrows

### DIFF
--- a/script.js
+++ b/script.js
@@ -269,7 +269,7 @@ async function initCatalog() {
       const btn = document.createElement('button');
       btn.className = 'category-toggle';
       btn.setAttribute('aria-expanded', 'false');
-      btn.innerHTML = `${catTitle}<span class="arrow">▶</span>`;
+      btn.innerHTML = `${catTitle}<span class="arrow" aria-hidden="true">▶</span>`;
       li.appendChild(btn);
 
       const subUl = document.createElement('ul');


### PR DESCRIPTION
## Summary
- hide navigation arrows from screen readers by marking arrow span as aria-hidden

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b07a8c8e38832b82f56107926f8af0