### PR TITLE
Add global navigation menu and supporting pages

### DIFF
--- a/ai-compliance.html
+++ b/ai-compliance.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="cs">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Katalog využití umělé inteligence ve veřejném sektoru</title>
+    <title>AI compliance – Katalog využití umělé inteligence ve veřejném sektoru</title>
     <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
     <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
@@ -12,7 +11,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 
-<body id="project-page">
+<body>
   <a href="#main" class="skip-link">Přeskočit na obsah</a>
   <header>
     <div>
@@ -35,9 +34,9 @@
   <nav class="main-nav" aria-label="Hlavní navigace">
     <div class="main-nav__container">
       <ul class="main-nav__list">
-        <li><a class="main-nav__link" href="project.html" aria-current="page">Katalog</a></li>
+        <li><a class="main-nav__link" href="project.html">Katalog</a></li>
         <li><a class="main-nav__link" href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a class="main-nav__link" href="ai-compliance.html">AI compliance</a></li>
+        <li><a class="main-nav__link" href="ai-compliance.html" aria-current="page">AI compliance</a></li>
         <li><a class="main-nav__link" href="clanky.html">Články</a></li>
         <li><a class="main-nav__link" href="slovnicek.html">Slovníček</a></li>
         <li><a class="main-nav__link" href="wiki.html">Přidat use case</a></li>
@@ -50,7 +49,7 @@
       <ul class="mobile-nav__list">
         <li class="mobile-nav__item mobile-nav__item--catalog">
           <div class="mobile-nav__item-header">
-            <a href="project.html" aria-current="page">Katalog</a>
+            <a href="project.html">Katalog</a>
             <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mobile-catalog-list"
                     data-toggle="mobile-catalog-list">
               <span class="visually-hidden">Rozbalit položky Katalog</span>
@@ -60,7 +59,7 @@
           <ul class="mobile-nav__submenu" id="mobile-catalog-list" hidden></ul>
         </li>
         <li class="mobile-nav__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li class="mobile-nav__item"><a href="ai-compliance.html">AI compliance</a></li>
+        <li class="mobile-nav__item"><a href="ai-compliance.html" aria-current="page">AI compliance</a></li>
         <li class="mobile-nav__item"><a href="clanky.html">Články</a></li>
         <li class="mobile-nav__item"><a href="slovnicek.html">Slovníček</a></li>
         <li class="mobile-nav__item"><a href="wiki.html">Přidat use case</a></li>
@@ -68,15 +67,30 @@
     </nav>
   </div>
 
-
-    <div class="content">
-    <aside id="sidebar">
-        <nav aria-label="Přehled use casů">
-            <ul id="usecase-list"></ul>
-        </nav>
-    </aside>
-    <main id="main"></main>
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <h2>Co je AI compliance</h2>
+        <p>
+          AI compliance označuje soulad využití umělé inteligence s právními předpisy, etickými pravidly a interními
+          standardy instituce. Zahrnuje nastavení procesů, které zajišťují transparentní sběr a zpracování dat,
+          dodržování zásad ochrany osobních údajů, posuzování rizik a pravidelné vyhodnocování dopadů AI na občany.
+        </p>
+        <p>
+          Správně nastavený rámec AI compliance pomáhá předcházet právním i reputačním rizikům, podporuje důvěru
+          veřejnosti a umožňuje instituci reagovat na nové regulatorní požadavky, například připravovaný Akt o
+          umělé inteligenci (AI Act) na úrovni EU.
+        </p>
+        <h3>Klíčové prvky AI compliance</h3>
+        <ul>
+          <li>Stanovení odpovědností za dohled nad AI řešeními v organizaci.</li>
+          <li>Posuzování dopadů na ochranu osobních údajů a základních práv.</li>
+          <li>Transparentní dokumentace datových zdrojů, modelů a rozhodovacích procesů.</li>
+          <li>Kontinuální monitoring kvality a bezpečnosti AI systémů.</li>
+        </ul>
+      </section>
     </div>
+  </main>
 
   <footer>
     <div>
@@ -90,7 +104,7 @@
         <section class="footer-block">
           <h3>Informace</h3>
           <p><a href="podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
-          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
         </section>
         <section class="footer-block">
           <h3>Kontakty</h3>
@@ -114,7 +128,7 @@
             <img src="logos/dia_logo.svg" alt="DIA logo">
           </div>
           <div class="footer-block">
-            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
               digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
               financovaného Evropskou unií NextGeneration.</p>
             <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
@@ -122,34 +136,12 @@
         </div>
       </section>
       <div class="footer-bottom">
-        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
       </div>
     </div>
   </footer>
 
-<div id="ai-tip-popup" class="popup" aria-hidden="true">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Close">&times;</button>
-    <p>Máte tip na inspirativní projekt s AI ve veřejném sektoru?
-    Přidejte svůj příspěvek <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMnjLBUkiFR6cAExs28azQ6emrvqm1ptWcizBmWRx2Om3ejQ/viewform?usp=dialog" target="_blank" rel="noopener">zde</a> a my jej rádi zařadíme do katalogu.
-</p>
-  </div>
-</div>
-
-<div id="category-popup" class="category-popup" aria-hidden="true" role="dialog">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Zavřít">&times;</button>
-    <h3></h3>
-    <p></p>
-  </div>
-</div>
-
-    <!-- Stáhnout PDF tlačítko – zůstane nad pop-up okny -->
-<a href="PDF/AI_use-cases.pdf" id="downloadBtn" class="download-btn" title="Stáhnout PDF" target="_blank" rel="noopener noreferrer">
-  <img src="icons/download_.svg" alt="Stáhnout PDF" width="20" height="20">
-</a>
-
-<script src="script.js"></script>
+  <script src="script.js"></script>
 </body>
 
 </html>

--- a/ai-gramotnost.html
+++ b/ai-gramotnost.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="cs">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Katalog využití umělé inteligence ve veřejném sektoru</title>
+    <title>AI gramotnost – Katalog využití umělé inteligence ve veřejném sektoru</title>
     <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
     <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
@@ -12,7 +11,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 
-<body id="project-page">
+<body>
   <a href="#main" class="skip-link">Přeskočit na obsah</a>
   <header>
     <div>
@@ -35,8 +34,8 @@
   <nav class="main-nav" aria-label="Hlavní navigace">
     <div class="main-nav__container">
       <ul class="main-nav__list">
-        <li><a class="main-nav__link" href="project.html" aria-current="page">Katalog</a></li>
-        <li><a class="main-nav__link" href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a class="main-nav__link" href="project.html">Katalog</a></li>
+        <li><a class="main-nav__link" href="ai-gramotnost.html" aria-current="page">AI gramotnost</a></li>
         <li><a class="main-nav__link" href="ai-compliance.html">AI compliance</a></li>
         <li><a class="main-nav__link" href="clanky.html">Články</a></li>
         <li><a class="main-nav__link" href="slovnicek.html">Slovníček</a></li>
@@ -50,7 +49,7 @@
       <ul class="mobile-nav__list">
         <li class="mobile-nav__item mobile-nav__item--catalog">
           <div class="mobile-nav__item-header">
-            <a href="project.html" aria-current="page">Katalog</a>
+            <a href="project.html">Katalog</a>
             <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mobile-catalog-list"
                     data-toggle="mobile-catalog-list">
               <span class="visually-hidden">Rozbalit položky Katalog</span>
@@ -59,7 +58,7 @@
           </div>
           <ul class="mobile-nav__submenu" id="mobile-catalog-list" hidden></ul>
         </li>
-        <li class="mobile-nav__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li class="mobile-nav__item"><a href="ai-gramotnost.html" aria-current="page">AI gramotnost</a></li>
         <li class="mobile-nav__item"><a href="ai-compliance.html">AI compliance</a></li>
         <li class="mobile-nav__item"><a href="clanky.html">Články</a></li>
         <li class="mobile-nav__item"><a href="slovnicek.html">Slovníček</a></li>
@@ -68,15 +67,29 @@
     </nav>
   </div>
 
-
-    <div class="content">
-    <aside id="sidebar">
-        <nav aria-label="Přehled use casů">
-            <ul id="usecase-list"></ul>
-        </nav>
-    </aside>
-    <main id="main"></main>
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <h2>Co je AI gramotnost</h2>
+        <p>
+          AI gramotnost představuje schopnost porozumět možnostem, omezením a dopadům umělé inteligence a
+          využívat ji bezpečným a zodpovědným způsobem. Zahrnuje základní porozumění tomu, jak systémy AI fungují,
+          jak pracují s daty a jaké otázky klást při rozhodování o jejich nasazení ve veřejném sektoru.
+        </p>
+        <p>
+          Cílem AI gramotnosti je posílit dovednosti pracovníků veřejné správy i široké veřejnosti tak, aby dokázali
+          rozpoznat, kdy je AI vhodným řešením, jaké jsou s jejím využitím spojené přínosy a rizika a jak zajistit, aby
+          technologie sloužila veřejnému zájmu.
+        </p>
+        <h3>Základní oblasti AI gramotnosti</h3>
+        <ul>
+          <li>Porozumění principům fungování algoritmů a datové práce.</li>
+          <li>Schopnost hodnotit etické, právní a společenské dopady nasazení AI.</li>
+          <li>Orientace v praktických scénářích využití AI ve veřejné správě.</li>
+        </ul>
+      </section>
     </div>
+  </main>
 
   <footer>
     <div>
@@ -90,7 +103,7 @@
         <section class="footer-block">
           <h3>Informace</h3>
           <p><a href="podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
-          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
         </section>
         <section class="footer-block">
           <h3>Kontakty</h3>
@@ -114,7 +127,7 @@
             <img src="logos/dia_logo.svg" alt="DIA logo">
           </div>
           <div class="footer-block">
-            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
               digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
               financovaného Evropskou unií NextGeneration.</p>
             <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
@@ -122,34 +135,12 @@
         </div>
       </section>
       <div class="footer-bottom">
-        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
       </div>
     </div>
   </footer>
 
-<div id="ai-tip-popup" class="popup" aria-hidden="true">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Close">&times;</button>
-    <p>Máte tip na inspirativní projekt s AI ve veřejném sektoru?
-    Přidejte svůj příspěvek <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMnjLBUkiFR6cAExs28azQ6emrvqm1ptWcizBmWRx2Om3ejQ/viewform?usp=dialog" target="_blank" rel="noopener">zde</a> a my jej rádi zařadíme do katalogu.
-</p>
-  </div>
-</div>
-
-<div id="category-popup" class="category-popup" aria-hidden="true" role="dialog">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Zavřít">&times;</button>
-    <h3></h3>
-    <p></p>
-  </div>
-</div>
-
-    <!-- Stáhnout PDF tlačítko – zůstane nad pop-up okny -->
-<a href="PDF/AI_use-cases.pdf" id="downloadBtn" class="download-btn" title="Stáhnout PDF" target="_blank" rel="noopener noreferrer">
-  <img src="icons/download_.svg" alt="Stáhnout PDF" width="20" height="20">
-</a>
-
-<script src="script.js"></script>
+  <script src="script.js"></script>
 </body>
 
 </html>

--- a/clanky.html
+++ b/clanky.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="cs">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Katalog využití umělé inteligence ve veřejném sektoru</title>
+    <title>Články – Katalog využití umělé inteligence ve veřejném sektoru</title>
     <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
     <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
@@ -12,7 +11,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 
-<body id="project-page">
+<body>
   <a href="#main" class="skip-link">Přeskočit na obsah</a>
   <header>
     <div>
@@ -35,10 +34,10 @@
   <nav class="main-nav" aria-label="Hlavní navigace">
     <div class="main-nav__container">
       <ul class="main-nav__list">
-        <li><a class="main-nav__link" href="project.html" aria-current="page">Katalog</a></li>
+        <li><a class="main-nav__link" href="project.html">Katalog</a></li>
         <li><a class="main-nav__link" href="ai-gramotnost.html">AI gramotnost</a></li>
         <li><a class="main-nav__link" href="ai-compliance.html">AI compliance</a></li>
-        <li><a class="main-nav__link" href="clanky.html">Články</a></li>
+        <li><a class="main-nav__link" href="clanky.html" aria-current="page">Články</a></li>
         <li><a class="main-nav__link" href="slovnicek.html">Slovníček</a></li>
         <li><a class="main-nav__link" href="wiki.html">Přidat use case</a></li>
       </ul>
@@ -50,7 +49,7 @@
       <ul class="mobile-nav__list">
         <li class="mobile-nav__item mobile-nav__item--catalog">
           <div class="mobile-nav__item-header">
-            <a href="project.html" aria-current="page">Katalog</a>
+            <a href="project.html">Katalog</a>
             <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mobile-catalog-list"
                     data-toggle="mobile-catalog-list">
               <span class="visually-hidden">Rozbalit položky Katalog</span>
@@ -61,22 +60,46 @@
         </li>
         <li class="mobile-nav__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
         <li class="mobile-nav__item"><a href="ai-compliance.html">AI compliance</a></li>
-        <li class="mobile-nav__item"><a href="clanky.html">Články</a></li>
+        <li class="mobile-nav__item"><a href="clanky.html" aria-current="page">Články</a></li>
         <li class="mobile-nav__item"><a href="slovnicek.html">Slovníček</a></li>
         <li class="mobile-nav__item"><a href="wiki.html">Přidat use case</a></li>
       </ul>
     </nav>
   </div>
 
-
-    <div class="content">
-    <aside id="sidebar">
-        <nav aria-label="Přehled use casů">
-            <ul id="usecase-list"></ul>
-        </nav>
-    </aside>
-    <main id="main"></main>
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <h2>Články a inspirace</h2>
+        <p>Připravili jsme ukázkové články, které ilustrují možné příspěvky do připravované rubriky.</p>
+        <article class="card" style="margin-bottom: 1.5rem; padding: 1.5rem;">
+          <h3>Transformace služeb pro občany pomocí AI</h3>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eget massa ac velit sollicitudin
+            condimentum. Vestibulum eget arcu vitae lectus ullamcorper cursus sed vitae lorem. Aenean consequat
+            malesuada turpis, eu aliquet lorem dapibus nec.
+          </p>
+          <p><a href="#">Pokračovat ve čtení</a></p>
+        </article>
+        <article class="card" style="margin-bottom: 1.5rem; padding: 1.5rem;">
+          <h3>Jak nastavit governance pro AI projekty</h3>
+          <p>
+            Nulla facilisi. Integer finibus, erat quis pulvinar ultricies, ipsum lacus dignissim nisi, non fermentum
+            sapien mi sit amet neque. Donec non est sit amet augue dignissim auctor. Cras sit amet libero mi.
+          </p>
+          <p><a href="#">Pokračovat ve čtení</a></p>
+        </article>
+        <article class="card" style="padding: 1.5rem;">
+          <h3>Odpovědné využití dat ve veřejné správě</h3>
+          <p>
+            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+            aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+          </p>
+          <p><a href="#">Pokračovat ve čtení</a></p>
+        </article>
+      </section>
     </div>
+  </main>
 
   <footer>
     <div>
@@ -90,7 +113,7 @@
         <section class="footer-block">
           <h3>Informace</h3>
           <p><a href="podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
-          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
         </section>
         <section class="footer-block">
           <h3>Kontakty</h3>
@@ -114,7 +137,7 @@
             <img src="logos/dia_logo.svg" alt="DIA logo">
           </div>
           <div class="footer-block">
-            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
               digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
               financovaného Evropskou unií NextGeneration.</p>
             <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
@@ -122,34 +145,12 @@
         </div>
       </section>
       <div class="footer-bottom">
-        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
       </div>
     </div>
   </footer>
 
-<div id="ai-tip-popup" class="popup" aria-hidden="true">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Close">&times;</button>
-    <p>Máte tip na inspirativní projekt s AI ve veřejném sektoru?
-    Přidejte svůj příspěvek <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMnjLBUkiFR6cAExs28azQ6emrvqm1ptWcizBmWRx2Om3ejQ/viewform?usp=dialog" target="_blank" rel="noopener">zde</a> a my jej rádi zařadíme do katalogu.
-</p>
-  </div>
-</div>
-
-<div id="category-popup" class="category-popup" aria-hidden="true" role="dialog">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Zavřít">&times;</button>
-    <h3></h3>
-    <p></p>
-  </div>
-</div>
-
-    <!-- Stáhnout PDF tlačítko – zůstane nad pop-up okny -->
-<a href="PDF/AI_use-cases.pdf" id="downloadBtn" class="download-btn" title="Stáhnout PDF" target="_blank" rel="noopener noreferrer">
-  <img src="icons/download_.svg" alt="Stáhnout PDF" width="20" height="20">
-</a>
-
-<script src="script.js"></script>
+  <script src="script.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,14 @@
   <a href="#main" class="skip-link">Přeskočit na obsah</a>
   <header>
     <div>
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-nav" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+             stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
       <h1>
         <a href="/">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
@@ -22,6 +30,42 @@
       </h1>
     </div>
   </header>
+
+  <nav class="main-nav" aria-label="Hlavní navigace">
+    <div class="main-nav__container">
+      <ul class="main-nav__list">
+        <li><a class="main-nav__link" href="project.html">Katalog</a></li>
+        <li><a class="main-nav__link" href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a class="main-nav__link" href="ai-compliance.html">AI compliance</a></li>
+        <li><a class="main-nav__link" href="clanky.html">Články</a></li>
+        <li><a class="main-nav__link" href="slovnicek.html">Slovníček</a></li>
+        <li><a class="main-nav__link" href="wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-nav" class="mobile-nav" aria-hidden="true">
+    <nav aria-label="Hlavní menu (mobilní)">
+      <ul class="mobile-nav__list">
+        <li class="mobile-nav__item mobile-nav__item--catalog">
+          <div class="mobile-nav__item-header">
+            <a href="project.html">Katalog</a>
+            <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mobile-catalog-list"
+                    data-toggle="mobile-catalog-list">
+              <span class="visually-hidden">Rozbalit položky Katalog</span>
+              <span aria-hidden="true" class="mobile-nav__chevron">▸</span>
+            </button>
+          </div>
+          <ul class="mobile-nav__submenu" id="mobile-catalog-list" hidden></ul>
+        </li>
+        <li class="mobile-nav__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li class="mobile-nav__item"><a href="ai-compliance.html">AI compliance</a></li>
+        <li class="mobile-nav__item"><a href="clanky.html">Články</a></li>
+        <li class="mobile-nav__item"><a href="slovnicek.html">Slovníček</a></li>
+        <li class="mobile-nav__item"><a href="wiki.html">Přidat use case</a></li>
+      </ul>
+    </nav>
+  </div>
 
  <main id="main">
     <div>

--- a/podminky.html
+++ b/podminky.html
@@ -15,6 +15,14 @@
   <a href="#main" class="skip-link">Přeskočit na obsah</a>
   <header>
     <div>
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-nav" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+             stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
       <h1>
         <a href="/">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
@@ -22,6 +30,42 @@
       </h1>
     </div>
   </header>
+
+  <nav class="main-nav" aria-label="Hlavní navigace">
+    <div class="main-nav__container">
+      <ul class="main-nav__list">
+        <li><a class="main-nav__link" href="project.html">Katalog</a></li>
+        <li><a class="main-nav__link" href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a class="main-nav__link" href="ai-compliance.html">AI compliance</a></li>
+        <li><a class="main-nav__link" href="clanky.html">Články</a></li>
+        <li><a class="main-nav__link" href="slovnicek.html">Slovníček</a></li>
+        <li><a class="main-nav__link" href="wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-nav" class="mobile-nav" aria-hidden="true">
+    <nav aria-label="Hlavní menu (mobilní)">
+      <ul class="mobile-nav__list">
+        <li class="mobile-nav__item mobile-nav__item--catalog">
+          <div class="mobile-nav__item-header">
+            <a href="project.html">Katalog</a>
+            <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mobile-catalog-list"
+                    data-toggle="mobile-catalog-list">
+              <span class="visually-hidden">Rozbalit položky Katalog</span>
+              <span aria-hidden="true" class="mobile-nav__chevron">▸</span>
+            </button>
+          </div>
+          <ul class="mobile-nav__submenu" id="mobile-catalog-list" hidden></ul>
+        </li>
+        <li class="mobile-nav__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li class="mobile-nav__item"><a href="ai-compliance.html">AI compliance</a></li>
+        <li class="mobile-nav__item"><a href="clanky.html">Články</a></li>
+        <li class="mobile-nav__item"><a href="slovnicek.html">Slovníček</a></li>
+        <li class="mobile-nav__item"><a href="wiki.html">Přidat use case</a></li>
+      </ul>
+    </nav>
+  </div>
 
     <main id="main">
      <div>

--- a/slovnicek.html
+++ b/slovnicek.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="cs">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Katalog využití umělé inteligence ve veřejném sektoru</title>
+    <title>Slovníček – Katalog využití umělé inteligence ve veřejném sektoru</title>
     <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
     <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
     <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
@@ -12,7 +11,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 
-<body id="project-page">
+<body>
   <a href="#main" class="skip-link">Přeskočit na obsah</a>
   <header>
     <div>
@@ -35,11 +34,11 @@
   <nav class="main-nav" aria-label="Hlavní navigace">
     <div class="main-nav__container">
       <ul class="main-nav__list">
-        <li><a class="main-nav__link" href="project.html" aria-current="page">Katalog</a></li>
+        <li><a class="main-nav__link" href="project.html">Katalog</a></li>
         <li><a class="main-nav__link" href="ai-gramotnost.html">AI gramotnost</a></li>
         <li><a class="main-nav__link" href="ai-compliance.html">AI compliance</a></li>
         <li><a class="main-nav__link" href="clanky.html">Články</a></li>
-        <li><a class="main-nav__link" href="slovnicek.html">Slovníček</a></li>
+        <li><a class="main-nav__link" href="slovnicek.html" aria-current="page">Slovníček</a></li>
         <li><a class="main-nav__link" href="wiki.html">Přidat use case</a></li>
       </ul>
     </div>
@@ -50,7 +49,7 @@
       <ul class="mobile-nav__list">
         <li class="mobile-nav__item mobile-nav__item--catalog">
           <div class="mobile-nav__item-header">
-            <a href="project.html" aria-current="page">Katalog</a>
+            <a href="project.html">Katalog</a>
             <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mobile-catalog-list"
                     data-toggle="mobile-catalog-list">
               <span class="visually-hidden">Rozbalit položky Katalog</span>
@@ -62,21 +61,19 @@
         <li class="mobile-nav__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
         <li class="mobile-nav__item"><a href="ai-compliance.html">AI compliance</a></li>
         <li class="mobile-nav__item"><a href="clanky.html">Články</a></li>
-        <li class="mobile-nav__item"><a href="slovnicek.html">Slovníček</a></li>
+        <li class="mobile-nav__item"><a href="slovnicek.html" aria-current="page">Slovníček</a></li>
         <li class="mobile-nav__item"><a href="wiki.html">Přidat use case</a></li>
       </ul>
     </nav>
   </div>
 
-
-    <div class="content">
-    <aside id="sidebar">
-        <nav aria-label="Přehled use casů">
-            <ul id="usecase-list"></ul>
-        </nav>
-    </aside>
-    <main id="main"></main>
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <h2>Slovníček</h2>
+      </section>
     </div>
+  </main>
 
   <footer>
     <div>
@@ -90,7 +87,7 @@
         <section class="footer-block">
           <h3>Informace</h3>
           <p><a href="podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
-          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
         </section>
         <section class="footer-block">
           <h3>Kontakty</h3>
@@ -114,7 +111,7 @@
             <img src="logos/dia_logo.svg" alt="DIA logo">
           </div>
           <div class="footer-block">
-            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
               digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
               financovaného Evropskou unií NextGeneration.</p>
             <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
@@ -122,34 +119,12 @@
         </div>
       </section>
       <div class="footer-bottom">
-        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
       </div>
     </div>
   </footer>
 
-<div id="ai-tip-popup" class="popup" aria-hidden="true">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Close">&times;</button>
-    <p>Máte tip na inspirativní projekt s AI ve veřejném sektoru?
-    Přidejte svůj příspěvek <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMnjLBUkiFR6cAExs28azQ6emrvqm1ptWcizBmWRx2Om3ejQ/viewform?usp=dialog" target="_blank" rel="noopener">zde</a> a my jej rádi zařadíme do katalogu.
-</p>
-  </div>
-</div>
-
-<div id="category-popup" class="category-popup" aria-hidden="true" role="dialog">
-  <div class="popup-content">
-    <button class="popup-close" aria-label="Zavřít">&times;</button>
-    <h3></h3>
-    <p></p>
-  </div>
-</div>
-
-    <!-- Stáhnout PDF tlačítko – zůstane nad pop-up okny -->
-<a href="PDF/AI_use-cases.pdf" id="downloadBtn" class="download-btn" title="Stáhnout PDF" target="_blank" rel="noopener noreferrer">
-  <img src="icons/download_.svg" alt="Stáhnout PDF" width="20" height="20">
-</a>
-
-<script src="script.js"></script>
+  <script src="script.js"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,8 @@
     --secondary: #f2f6fa;
     --text: #1a1a1a;
     --sidebar-width: 260px;
+    --header-height: 103px;
+    --nav-height: 56px;
 }
 
 /* latin-ext */
@@ -57,10 +59,23 @@ html {
 
 body {
     padding:0;
+    padding-top: var(--header-height);
     margin:0;
     position: relative;
     min-height: 100vh;
     background: #f5f5f5;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 body > header > div, body > footer > div, body > main > div,
@@ -241,6 +256,9 @@ body > header {
 
 body > header > div {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
     height: 100%;
     margin: 0 auto;
 }
@@ -295,6 +313,152 @@ body > header h1 a {
 .hamburger:focus {
     outline: 2px solid var(--primary);
     outline-offset: 2px;
+}
+
+/* ===== Main navigation ===== */
+.main-nav {
+    position: sticky;
+    top: var(--header-height);
+    background: var(--primary);
+    color: #ffffff;
+    width: 100%;
+    z-index: 900;
+}
+
+.main-nav__container {
+    margin: 0 auto;
+    max-width: 75rem;
+    padding: 0 clamp(1rem, 4vw, 3rem);
+}
+
+.main-nav__list {
+    display: flex;
+    gap: clamp(1rem, 3vw, 2.5rem);
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    min-height: var(--nav-height);
+}
+
+.main-nav__link {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 0;
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+
+.main-nav__link:hover,
+.main-nav__link:focus {
+    text-decoration: underline;
+    color: #ffffff;
+}
+
+.main-nav__link[aria-current="page"] {
+    text-decoration: underline;
+}
+
+/* ===== Mobile navigation (hamburger) ===== */
+#mobile-nav {
+    position: fixed;
+    inset: 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    background: #ffffff;
+    z-index: 950;
+    padding-top: var(--header-height);
+    overflow-y: auto;
+}
+
+#mobile-nav.open {
+    transform: translateX(0);
+}
+
+#mobile-nav nav {
+    padding: 1.5rem clamp(1rem, 6vw, 2.5rem) 3rem;
+}
+
+.mobile-nav__list,
+.mobile-nav__submenu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.mobile-nav__item {
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.mobile-nav__item > a,
+.mobile-nav__item-header > a {
+    display: block;
+    padding: 0.85rem 0;
+    color: var(--text);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.mobile-nav__item > a:hover,
+.mobile-nav__item > a:focus,
+.mobile-nav__item-header > a:hover,
+.mobile-nav__item-header > a:focus {
+    color: var(--primary);
+}
+
+.mobile-nav__item-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.mobile-nav__toggle,
+.mobile-nav__submenu-toggle {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0.85rem 0;
+    font: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.mobile-nav__toggle:focus,
+.mobile-nav__submenu-toggle:focus {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
+.mobile-nav__chevron {
+    transition: transform 0.2s ease;
+    display: inline-flex;
+    font-size: 1.1rem;
+}
+
+.mobile-nav__toggle[aria-expanded="true"] .mobile-nav__chevron,
+.mobile-nav__submenu-toggle[aria-expanded="true"] .mobile-nav__chevron {
+    transform: rotate(90deg);
+}
+
+.mobile-nav__submenu {
+    padding-left: 1rem;
+}
+
+.mobile-nav__submenu-item a {
+    display: block;
+    padding: 0.65rem 0;
+    color: var(--text);
+    text-decoration: none;
+}
+
+.mobile-nav__submenu-item a:hover,
+.mobile-nav__submenu-item a:focus {
+    color: var(--primary);
 }
 
 /* ===== Footer ===== */
@@ -517,15 +681,14 @@ footer .footer-bottom p {
     background: var(--secondary);
     border-right: 1px solid #d9e2ec;
     overflow-y: visible;   /* ať se nezalamuje uvnitř */
-    padding: 103px 0 1rem;
-    /* for fixed topbar */
-    position: relative;
-    top: 0;
-    transition: transform 0.3s ease;
+    padding: calc(var(--nav-height) + 1rem) 0 1rem;
+    position: sticky;
+    top: calc(var(--header-height) + 1rem);
     grid-row: 2;
     grid-column: 1;
     max-width: 260px;
     box-sizing: border-box;
+    height: fit-content;
 }
 
 nav ul {
@@ -599,7 +762,7 @@ nav ul li:last-child {
 
 /* ===== Main content ===== */
 main {
-    padding-top: 127px;  /* offset for header */
+    padding-top: calc(var(--nav-height) + 2rem);
     padding-bottom: 3rem;
     overflow-y: auto;
     background: #f5f5f5;
@@ -611,7 +774,7 @@ body#project-page main {
 }
 
 body#project-page .content section {
-    scroll-margin-top: 127px;
+    scroll-margin-top: calc(var(--header-height) + var(--nav-height) + 24px);
     display: none;
     /* show only selected */
 }
@@ -835,27 +998,31 @@ h3 {
 /* malá hlavička na mobilu, bez ohledu na orientaci portrait, landscape */
 @media (max-width: 768px), (max-height:  768px) {
     body > header {
-        height: 56px;
-    }
-
-    #sidebar {
-        padding-top: 56px;
-    }
-
-    main {
-        padding-top: 80px;
+        height: var(--header-height);
     }
 
     body#project-page .content section {
-        scroll-margin-top: 80px;
+        scroll-margin-top: calc(var(--header-height) + 24px);
     }
 }
 
 @media (max-width: 768px) {
+    :root {
+        --header-height: 56px;
+        --nav-height: 0px;
+    }
+
     body {
         grid-template-columns: 1fr;
     }
 
+    .main-nav {
+        display: none;
+    }
+
+    #mobile-nav {
+        padding-top: var(--header-height);
+    }
 
   .hero-banner {
     background-color: #f0f0f0; /* příklad */
@@ -866,29 +1033,8 @@ h3 {
       max-width: 500px;
   }
 
-    /* Sidebar chování */
     #sidebar {
-        position: fixed;
-        left: 0;
-        top: 0;
-        width: var(--sidebar-width);
-        max-height: calc(100vh - var(--footer-height, 60px)); /* nedosahuje na footer */
-        overflow-y: auto; /* umožní scroll uvnitř sidebaru */
-        transform: translateX(-100%);
-        z-index: 999;
-        transition: transform 0.3s ease;
-    }
-
-    #sidebar.open {
-        transform: translateX(0);
-    }
-
-    #sidebar .arrow {        /* nebo konkrétní třída šipky */
-        display: inline-block;
-        vertical-align: middle;
-        margin-left: 0.5em;
-        width: 1em;
-        height: auto;
+        display: none;
     }
 
     footer .footer-project div {

--- a/wiki.html
+++ b/wiki.html
@@ -15,6 +15,14 @@
   <a href="#main" class="skip-link">Přeskočit na obsah</a>
   <header>
     <div>
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-nav" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+             stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
       <h1>
         <a href="/">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
@@ -22,6 +30,42 @@
       </h1>
     </div>
   </header>
+
+  <nav class="main-nav" aria-label="Hlavní navigace">
+    <div class="main-nav__container">
+      <ul class="main-nav__list">
+        <li><a class="main-nav__link" href="project.html">Katalog</a></li>
+        <li><a class="main-nav__link" href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a class="main-nav__link" href="ai-compliance.html">AI compliance</a></li>
+        <li><a class="main-nav__link" href="clanky.html">Články</a></li>
+        <li><a class="main-nav__link" href="slovnicek.html">Slovníček</a></li>
+        <li><a class="main-nav__link" href="wiki.html" aria-current="page">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-nav" class="mobile-nav" aria-hidden="true">
+    <nav aria-label="Hlavní menu (mobilní)">
+      <ul class="mobile-nav__list">
+        <li class="mobile-nav__item mobile-nav__item--catalog">
+          <div class="mobile-nav__item-header">
+            <a href="project.html">Katalog</a>
+            <button type="button" class="mobile-nav__toggle" aria-expanded="false" aria-controls="mobile-catalog-list"
+                    data-toggle="mobile-catalog-list">
+              <span class="visually-hidden">Rozbalit položky Katalog</span>
+              <span aria-hidden="true" class="mobile-nav__chevron">▸</span>
+            </button>
+          </div>
+          <ul class="mobile-nav__submenu" id="mobile-catalog-list" hidden></ul>
+        </li>
+        <li class="mobile-nav__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
+        <li class="mobile-nav__item"><a href="ai-compliance.html">AI compliance</a></li>
+        <li class="mobile-nav__item"><a href="clanky.html">Články</a></li>
+        <li class="mobile-nav__item"><a href="slovnicek.html">Slovníček</a></li>
+        <li class="mobile-nav__item"><a href="wiki.html" aria-current="page">Přidat use case</a></li>
+      </ul>
+    </nav>
+  </div>
 
 
   <main id="main">


### PR DESCRIPTION
## Summary
- add a global desktop navigation bar and mobile hamburger menu across all public pages
- extend scripts and styles to populate the nested mobile catalog menu and restyle layout offsets
- create placeholder content pages for AI gramotnost, AI compliance, články and slovníček

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdb2a2dc88832caec375878d098a03