### PR TITLE
Add animated use case counter block to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,14 @@
             veřejná správa stavět svou digitální budoucnost.</p>
         </div>
         <div><a href="wiki.html" class="btn-secondary" aria-label="Přidat use case">Přidat use case</a></div>
+        <section class="usecase-counter" data-target="128" aria-live="polite">
+          <div class="usecase-counter__inner">
+            <p class="usecase-counter__lead">V katalogu již máme</p>
+            <p class="usecase-counter__value"><span data-counter-value>0</span></p>
+            <p class="usecase-counter__suffix">use cases</p>
+          </div>
+          <div class="usecase-counter__glow" aria-hidden="true"></div>
+        </section>
       </section>
       <div id="table-overview-container"></div>
       <script src="table-overview.js"></script>

--- a/script.js
+++ b/script.js
@@ -151,6 +151,70 @@ function initInfoBanner() {
 }
 
 /** ======================
+ *  Počítadlo use casů
+ *  ====================== */
+function initUsecaseCounter() {
+  const counter = document.querySelector('.usecase-counter');
+  if (!counter) return;
+
+  const valueEl = counter.querySelector('[data-counter-value]');
+  const targetValue = Number(counter.dataset.target);
+  if (!valueEl || !Number.isFinite(targetValue)) return;
+
+  const format = value => new Intl.NumberFormat('cs-CZ').format(Math.round(value));
+  const prefersReducedMotion = typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const revealFinalValue = () => {
+    valueEl.textContent = format(targetValue);
+    counter.classList.add('usecase-counter--active');
+  };
+
+  if (prefersReducedMotion) {
+    revealFinalValue();
+    return;
+  }
+
+  let hasAnimated = false;
+
+  const animate = () => {
+    if (hasAnimated) return;
+    hasAnimated = true;
+    counter.classList.add('usecase-counter--active');
+
+    const duration = 2000;
+    const startValue = 0;
+    const startTime = performance.now();
+
+    const step = now => {
+      const progress = Math.min((now - startTime) / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      const current = startValue + (targetValue - startValue) * eased;
+      valueEl.textContent = format(current);
+      if (progress < 1) requestAnimationFrame(step);
+      else valueEl.textContent = format(targetValue);
+    };
+
+    requestAnimationFrame(step);
+  };
+
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          animate();
+          observer.disconnect();
+        }
+      });
+    }, { threshold: 0.4 });
+
+    observer.observe(counter);
+  } else {
+    animate();
+  }
+}
+
+/** ======================
  *  Pomocné funkce pro katalog
  *  ====================== */
 function createUseCaseSection(uc, categoryDescriptions) {
@@ -399,4 +463,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initCommon();
   initCatalog();
   initInfoBanner();
+  initUsecaseCounter();
 });

--- a/styles.css
+++ b/styles.css
@@ -826,6 +826,65 @@ footer .footer-bottom p {
     /* ikona zbělá */
 }
 
+.usecase-counter {
+    position: relative;
+    margin: 3.5rem auto 2rem;
+    padding: clamp(1.5rem, 4vw, 2.75rem) clamp(1.5rem, 6vw, 4rem);
+    max-width: 960px;
+    border-radius: 24px;
+    background: linear-gradient(135deg, rgba(27, 90, 20, 0.08), rgba(32, 115, 21, 0.18));
+    box-shadow: 0 18px 45px -20px rgba(26, 41, 29, 0.55);
+    overflow: hidden;
+}
+
+.usecase-counter__inner {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 0.5rem;
+    justify-items: center;
+    text-align: center;
+}
+
+.usecase-counter__lead {
+    font-size: clamp(1rem, 2vw, 1.25rem);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: #184e11;
+    font-weight: 600;
+}
+
+.usecase-counter__value {
+    font-size: clamp(3.5rem, 7vw, 5rem);
+    font-weight: 700;
+    line-height: 1;
+    color: #0d2f09;
+    text-shadow: 0 12px 24px rgba(19, 47, 20, 0.2);
+}
+
+.usecase-counter__suffix {
+    font-size: clamp(1.125rem, 2.5vw, 1.5rem);
+    color: #1f4d18;
+    font-weight: 500;
+}
+
+.usecase-counter__glow {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.65), transparent 55%),
+        radial-gradient(circle at 80% 30%, rgba(78, 178, 88, 0.35), transparent 60%),
+        radial-gradient(circle at 50% 85%, rgba(32, 115, 21, 0.25), transparent 65%);
+    pointer-events: none;
+    transition: opacity 0.6s ease;
+}
+
+.usecase-counter--active .usecase-counter__glow {
+    opacity: 1;
+}
+
+.usecase-counter:not(.usecase-counter--active) .usecase-counter__glow {
+    opacity: 0.35;
+}
 
 /* ===== Sidebar ===== */
 #sidebar {


### PR DESCRIPTION
## Summary
- add a decorative "usecase-counter" card to the landing page between the CTA and the overview table
- style the new block with gradient, glow accent, and responsive typography to match the marketing tone
- animate the displayed number from 0 to the target once the card enters the viewport using IntersectionObserver

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdd28a6fb8832ca58ee1496c3c5bbe