### PR TITLE
Add glossary overview and detail pages

### DIFF
--- a/slovnicek.html
+++ b/slovnicek.html
@@ -80,6 +80,67 @@
     <div>
       <section class="main-content">
         <h2>Slovníček</h2>
+        <p class="lead">Základní přehled pojmů, se kterými se úředníci a projektové týmy setkávají při plánování a realizaci
+          řešení využívajících umělou inteligenci.</p>
+        <div class="table-wrapper">
+          <table class="glossary-table">
+            <thead>
+              <tr>
+                <th scope="col">Preferovaný název</th>
+                <th scope="col">Definice / typ pojmu</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a href="slovnicek/umela-inteligence.html">Umělá inteligence</a>
+                </td>
+                <td>
+                  Systém, který je navržen tak, aby samostatně analyzoval data, vyvozoval závěry a generoval doporučení nebo akce
+                  s cílem plnit určené úkoly.
+                  <span class="glossary-tag">Základní pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/machine-learning.html">Machine learning (strojové učení)</a>
+                </td>
+                <td>
+                  Soubor algoritmů, které se zlepšují analýzou dat bez toho, aby musely být explicitně naprogramovány pro každý krok
+                  rozhodování.
+                  <span class="glossary-tag">Technický pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/generativni-ai.html">Generativní umělá inteligence</a>
+                </td>
+                <td>
+                  AI systémy, které vytvářejí nový obsah – text, obrázky, zvuk nebo kód – na základě naučených vzorů z existujících dat.
+                  <span class="glossary-tag">Technický pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/data-protection-impact-assessment.html">Data Protection Impact Assessment (posouzení vlivu na ochranu osobních údajů)</a>
+                </td>
+                <td>
+                  Proces podle čl. 35 GDPR, který vyhodnocuje rizika plánovaného zpracování osobních údajů a navrhuje opatření k jejich zmírnění.
+                  <span class="glossary-tag">Legální definice</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/data-governance.html">Data governance (řízení dat)</a>
+                </td>
+                <td>
+                  Soubor procesů a pravidel, které zajišťují kvalitu, bezpečnost a dostupnost dat v organizaci.
+                  <span class="glossary-tag">Organizační pojem</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   </main>

--- a/slovnicek.json
+++ b/slovnicek.json
@@ -1,0 +1,52 @@
+[
+  {
+    "slug": "umela-inteligence",
+    "preferredName": "Umělá inteligence",
+    "alternateName": "Artificial Intelligence",
+    "tag": "základní pojem",
+    "definition": "Systém, který je navržen tak, aby samostatně analyzoval data, vyvozoval závěry a generoval doporučení nebo akce s cílem plnit určené úkoly.",
+    "officialExplanation": "Umělá inteligence je zastřešující pojem pro technologie, které napodobují kognitivní funkce člověka. Ve veřejné správě pomáhá zrychlit rozhodování, zlepšit služby občanům a podpořit analytickou práci úředníků.",
+    "example": "Například klasifikátor příchozích podnětů, který rozpoznává typ žádosti a směřuje ji příslušnému útvaru, využívá AI k automatické interpretaci obsahu.",
+    "article": "Systémy AI mohou být založeny na pravidlech, strojovém učení nebo kombinaci obojího. Důležité je sledovat transparentnost a vysvětlitelnost výsledků, aby úředníci uměli obhájit svá rozhodnutí." 
+  },
+  {
+    "slug": "machine-learning",
+    "preferredName": "Machine learning",
+    "alternateName": "Strojové učení",
+    "tag": "technický pojem",
+    "definition": "Soubor algoritmů, které se zlepšují analýzou dat bez toho, aby musely být explicitně naprogramovány pro každý krok rozhodování.",
+    "officialExplanation": "Modely strojového učení se trénují na historických datech a učí se z nich hledat vzory. Úředníkům to umožňuje automatizovat úkoly, které by jinak vyžadovaly manuální kontrolu nebo rozsáhlé zkušenosti.",
+    "example": "Systém pro odhalování duplicitních podání využívá strojové učení ke srovnání různých formulářů a upozorňuje na podezřele podobné žádosti.",
+    "article": "Výběr vhodného algoritmu závisí na typu problému a dostupných datech. Je třeba sledovat kvalitu dat, aby výsledky nebyly zkreslené a nevedly k diskriminaci." 
+  },
+  {
+    "slug": "generativni-ai",
+    "preferredName": "Generativní umělá inteligence",
+    "alternateName": "Generative AI",
+    "tag": "technický pojem",
+    "definition": "AI systémy, které vytvářejí nový obsah – text, obrázky, zvuk nebo kód – na základě naučených vzorů z existujících dat.",
+    "officialExplanation": "Generativní AI lze využít pro přípravu návrhů dokumentů, sumarizaci spisů nebo tvorbu vizuálních materiálů. Vždy je však nutná lidská kontrola a schválení výstupu.",
+    "example": "Chatbot pro interní podporu úředníků generuje návrhy odpovědí na často kladené dotazy a úředník pouze upraví výsledný text.",
+    "article": "Tyto modely mohou omylem vytvářet nepravdivé informace. Doporučuje se zavést kontrolní mechanismy, logování generovaných výstupů a školení, jak s nástrojem bezpečně pracovat." 
+  },
+  {
+    "slug": "data-protection-impact-assessment",
+    "preferredName": "Data Protection Impact Assessment",
+    "alternateName": "Posouzení vlivu na ochranu osobních údajů",
+    "tag": "legální definice",
+    "definition": "Proces podle čl. 35 GDPR, který vyhodnocuje rizika plánovaného zpracování osobních údajů a navrhuje opatření k jejich zmírnění.",
+    "officialExplanation": "DPIA pomáhá úřadům posoudit, zda je plánované využití AI v souladu s ochranou soukromí. Je povinné, pokud může zpracování představovat vysoké riziko pro práva a svobody fyzických osob.",
+    "example": "Před nasazením systému, který automaticky vyhodnocuje rizikovost žadatelů o sociální dávky, úřad provede DPIA a zmapuje, jaké údaje se zpracovávají a kdo k nim má přístup.",
+    "article": "Součástí DPIA je popis zpracování, analýza nezbytnosti a proporcionality, identifikace rizik a návrh technických a organizačních opatření. Výstup musí být průkazně archivován a pravidelně aktualizován." 
+  },
+  {
+    "slug": "data-governance",
+    "preferredName": "Data governance",
+    "alternateName": "Řízení dat",
+    "tag": "organizační pojem",
+    "definition": "Soubor procesů a pravidel, které zajišťují kvalitu, bezpečnost a dostupnost dat v organizaci.",
+    "officialExplanation": "Dobré řízení dat stanovuje odpovědnosti za správu datových sad, nastavuje standardy a umožňuje úředníkům důvěřovat datům, která používají pro rozhodování a trénink AI modelů.",
+    "example": "Ministerstvo stanoví datového správce pro registr smluv, který dohlíží na kvalitu dat a pravidelně reportuje chyby k nápravě.",
+    "article": "Data governance zahrnuje katalog datových zdrojů, pravidla pro přístup a sdílení i koordinaci s kybernetickou bezpečností. Bez něj nelze dlouhodobě udržet důvěryhodnost AI řešení." 
+  }
+]

--- a/slovnicek/data-governance.html
+++ b/slovnicek/data-governance.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data governance – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-entry__back" href="../slovnicek.html">&larr; Zpět na přehled pojmů</a>
+        <h2>Data governance</h2>
+        <p class="glossary-entry__names">
+          <strong>Preferovaný název:</strong> Data governance<br>
+          <strong>Český ekvivalent:</strong> Řízení dat
+        </p>
+        <span class="glossary-tag">Organizační pojem</span>
+
+        <section>
+          <h3>Definice</h3>
+          <p>Soubor procesů a pravidel, které zajišťují kvalitu, bezpečnost a dostupnost dat v organizaci. Řeší také přidělení
+            odpovědností za správu dat a nastavuje standardy pro jejich využívání napříč úřadem.</p>
+        </section>
+
+        <section>
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Dobré řízení dat stanovuje, kdo je za jednotlivé datové sady odpovědný, jaké jsou postupy pro údržbu a sdílení dat a
+            jak se s daty pracuje při tréninku AI modelů. Úředníkům umožňuje důvěřovat informacím, které používají pro rozhodování,
+            a usnadňuje spolupráci mezi odbory.</p>
+        </section>
+
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Ministerstvo stanoví datového správce pro registr smluv, který dohlíží na kvalitu dat, koordinuje opravy s dodavateli a
+            pravidelně reportuje chyby k nápravě. Tým AI pak může stavět analytické nástroje na spolehlivém datovém základu.</p>
+        </section>
+
+        <section>
+          <h3>Doporučení a širší souvislosti</h3>
+          <p>Data governance zahrnuje katalog datových zdrojů, jasně popsané role a procesy pro přístup i sdílení dat. Měla by být
+            úzce propojena s kybernetickou bezpečností a ochranou osobních údajů. Bez těchto pravidel nelze dlouhodobě udržet
+            důvěryhodnost AI řešení ani plánovat jejich rozvoj.</p>
+          <p>Součástí je také průběžné vzdělávání zaměstnanců v práci s daty, nastavení metrik kvality a pravidelná kontrola, zda
+            jsou data aktuální. Dobrá governance umožní jednoduše doložit, odkud data pocházejí a jakými transformacemi prošla,
+            což je klíčové pro audit i veřejnou kontrolu.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/data-protection-impact-assessment.html
+++ b/slovnicek/data-protection-impact-assessment.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Protection Impact Assessment – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-entry__back" href="../slovnicek.html">&larr; Zpět na přehled pojmů</a>
+        <h2>Data Protection Impact Assessment</h2>
+        <p class="glossary-entry__names">
+          <strong>Preferovaný název:</strong> Data Protection Impact Assessment (DPIA)<br>
+          <strong>Český ekvivalent:</strong> Posouzení vlivu na ochranu osobních údajů
+        </p>
+        <span class="glossary-tag">Legální definice</span>
+
+        <section>
+          <h3>Definice</h3>
+          <p>Proces podle čl. 35 GDPR, který vyhodnocuje rizika plánovaného zpracování osobních údajů a navrhuje opatření k
+            jejich zmírnění. Slouží k prokázání, že správce přijal přiměřená technická a organizační opatření k ochraně práv
+            subjektů údajů.</p>
+        </section>
+
+        <section>
+          <h3>Co to znamená pro úředníky</h3>
+          <p>DPIA pomáhá úřadům posoudit, zda je plánované využití AI v souladu s ochranou soukromí. Je povinné, pokud může
+            zpracování představovat vysoké riziko pro práva a svobody fyzických osob – například při rozsáhlém profilování.
+            Úředníci díky DPIA získají jasný přehled o tom, jaká data se používají, kdo k nim má přístup a jaká opatření jsou
+            zavedena.</p>
+        </section>
+
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Před nasazením systému, který automaticky vyhodnocuje rizikovost žadatelů o sociální dávky, úřad provede DPIA.
+            Zmapuje, jaké údaje se zpracovávají, posoudí hrozby diskriminace a navrhne postupy pro ruční přezkum rozhodnutí,
+            aby bylo možné případné chyby napravit.</p>
+        </section>
+
+        <section>
+          <h3>Doporučení a širší souvislosti</h3>
+          <p>Součástí DPIA je popis zpracování, analýza nezbytnosti a proporcionality, identifikace rizik a návrh technických a
+            organizačních opatření. Doporučuje se zapojit pověřence pro ochranu osobních údajů a dokumentovat komunikaci s ÚOOÚ,
+            pokud si úřad není jistý výsledkem. Výstup DPIA musí být průkazně archivován a pravidelně aktualizován.</p>
+          <p>DPIA je dobré propojit s řízením rizik v oblasti kybernetické bezpečnosti a s interními směrnicemi pro správu dat.
+            Umožní to sledovat, zda se navržená opatření skutečně realizují a zda jsou náklady na ochranu soukromí vyvážené vůči
+            očekávaným přínosům projektu.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/generativni-ai.html
+++ b/slovnicek/generativni-ai.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generativní umělá inteligence – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-entry__back" href="../slovnicek.html">&larr; Zpět na přehled pojmů</a>
+        <h2>Generativní umělá inteligence</h2>
+        <p class="glossary-entry__names">
+          <strong>Preferovaný název:</strong> Generativní umělá inteligence<br>
+          <strong>Anglický ekvivalent:</strong> Generative AI
+        </p>
+        <span class="glossary-tag">Technický pojem</span>
+
+        <section>
+          <h3>Definice</h3>
+          <p>AI systémy, které vytvářejí nový obsah – text, obrázky, zvuk nebo kód – na základě naučených vzorů z existujících
+            dat. Využívají především hluboké neuronové sítě, které dokážou generovat konzistentní výstup odpovídající zadanému
+            zadání.</p>
+        </section>
+
+        <section>
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Generativní AI lze využít pro přípravu návrhů dokumentů, sumarizaci spisů nebo tvorbu vizuálních materiálů. Při
+            práci s těmito nástroji je vždy nutná lidská kontrola a schválení výstupu, aby nedocházelo k šíření nesprávných nebo
+            neaktuálních informací. Úředníci by měli znát zásady bezpečného používání a nepředávat systémům citlivé údaje.</p>
+        </section>
+
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Chatbot pro interní podporu úředníků generuje návrhy odpovědí na často kladené dotazy. Úředník návrh zkontroluje,
+            doplní potřebné kontextové informace a až poté jej odešle občanovi. Zrychlí se tak komunikace, ale zůstává zachována
+            odpovědnost člověka.</p>
+        </section>
+
+        <section>
+          <h3>Doporučení a širší souvislosti</h3>
+          <p>Tyto modely mohou vytvářet nepravdivé nebo zkreslené informace, zejména pokud nemají přístup k aktuálním datům. Proto
+            se doporučuje zavést kontrolní mechanismy, logování generovaných výstupů a školení uživatelů, jak s nástrojem bezpečně
+            pracovat. Je vhodné nastavit jasná pravidla, jaké typy úloh jsou pro generativní AI přípustné.</p>
+          <p>Součástí governance by měl být také dohled nad licencemi a autorskými právy k tréninkovým datům a výstupům. Transparentní
+            evidence použití modelu pomůže reagovat na případné stížnosti a umožní lépe plánovat budoucí rozvoj služby.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/machine-learning.html
+++ b/slovnicek/machine-learning.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Machine learning – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-entry__back" href="../slovnicek.html">&larr; Zpět na přehled pojmů</a>
+        <h2>Machine learning (strojové učení)</h2>
+        <p class="glossary-entry__names">
+          <strong>Preferovaný název:</strong> Machine learning<br>
+          <strong>Český ekvivalent:</strong> Strojové učení
+        </p>
+        <span class="glossary-tag">Technický pojem</span>
+
+        <section>
+          <h3>Definice</h3>
+          <p>Soubor algoritmů a statistických modelů, které se zlepšují analýzou dat bez toho, aby musely být explicitně
+            naprogramovány pro každý krok rozhodování. Model se během tréninku učí z historických příkladů a dokáže následně
+            odhadovat výsledky pro nová data.</p>
+        </section>
+
+        <section>
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Modely strojového učení se trénují na historických datech a učí se hledat vzory, které jsou lidskému oku často
+            skryté. Úředníkům tak umožňují automatizovat úkoly, jež by jinak vyžadovaly časově náročnou manuální kontrolu nebo
+            hluboké odborné zkušenosti. Je důležité rozumět tomu, z jakých dat model vychází a jak je nastavena validace, aby
+            byly výsledky důvěryhodné.</p>
+        </section>
+
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Systém pro odhalování duplicitních podání porovnává texty a strukturované údaje z formulářů a upozorňuje na
+            podezřele podobné žádosti. Úředník se poté zaměří na nejrizikovější případy a ušetří čas, který by strávil ručním
+            hledáním duplicit.</p>
+        </section>
+
+        <section>
+          <h3>Doporučení a širší souvislosti</h3>
+          <p>Výběr vhodného algoritmu závisí na typu problému a dostupných datech. Než se pustíte do tréninku, je potřeba
+            prověřit kvalitu dat, odstranit chyby a zajistit reprezentativnost. Výsledky musí být průběžně sledovány a
+            vyhodnocovány, aby se zabránilo driftu modelu a nespravedlivému zacházení s jednotlivými skupinami obyvatel.</p>
+          <p>Pro transparentnost je vhodné dokumentovat, jak byla data připravena, jaké metriky byly použity a kdo nese odpovědnost
+            za schvalování modelu i jeho aktualizace. Díky tomu lze jednoduše vysvětlit, proč algoritmus k danému rozhodnutí
+            dospěl, a zároveň se lépe plánují budoucí úpravy.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/umela-inteligence.html
+++ b/slovnicek/umela-inteligence.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Umělá inteligence – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-entry__back" href="../slovnicek.html">&larr; Zpět na přehled pojmů</a>
+        <h2>Umělá inteligence</h2>
+        <p class="glossary-entry__names">
+          <strong>Preferovaný název:</strong> Umělá inteligence<br>
+          <strong>Alternativní název:</strong> Artificial Intelligence
+        </p>
+        <span class="glossary-tag">Základní pojem</span>
+
+        <section>
+          <h3>Definice</h3>
+          <p>Systém, který je navržen tak, aby samostatně analyzoval data, vyvozoval závěry a generoval doporučení nebo akce s
+            cílem plnit určené úkoly. Zahrnuje jak pravidlové systémy, tak metody využívající strojové učení, které se učí z
+            dat a zlepšují svou přesnost v čase.</p>
+        </section>
+
+        <section>
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Umělá inteligence je zastřešující pojem pro technologie, které napodobují kognitivní funkce člověka. Ve veřejné
+            správě může významně pomoci se zrychlením rozhodování, automatizací rutinních činností a s analytickou prací nad
+            rozsáhlými datovými sadami. Aby bylo využití AI důvěryhodné, je potřeba mít jasno v tom, kdo systém spravuje, jak
+            je zajištěna kontrola kvality výstupů a jak se výsledky vysvětlují občanům.</p>
+        </section>
+
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Klasifikátor příchozích podnětů, který rozpoznává typ žádosti a směřuje ji příslušnému útvaru, využívá AI k
+            automatické interpretaci obsahu. Úředník pak dostává předpřipravené informace a může se soustředit na samotné
+            rozhodnutí místo zdlouhavého třídění.</p>
+        </section>
+
+        <section>
+          <h3>Doporučení a širší souvislosti</h3>
+          <p>Systémy AI mohou být založeny na pravidlech, strojovém učení nebo kombinaci obojího. Před nasazením je nutné
+            zhodnotit rizika, prověřit kvalitu dat a nastavit procesy průběžného monitoringu. Důležitá je transparentnost a
+            vysvětlitelnost výsledků, aby úředníci uměli obhájit svá rozhodnutí a mohli doložit, na základě čeho algoritmus
+            rozhodl.</p>
+          <p>Součástí governance by mělo být také jasně popsané rozdělení odpovědností za model, plán průběžného přezkumu a
+            způsob, jakým se budou sbírat a zohledňovat podněty od uživatelů i občanů. Jen tak lze zajistit, že AI bude v
+            praxi skutečně pomáhat a nebude ohrožovat práva jednotlivců.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1459,3 +1459,121 @@ table#table-overview tr>* {
 table#table-overview tr>*:first-child {
     width: 50%;
 }
+
+.table-wrapper {
+    margin-block: 2rem 3rem;
+    overflow-x: auto;
+}
+
+.glossary-table {
+    min-width: 640px;
+    border: 1px solid #d9d9d9;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+.glossary-table th {
+    background-color: var(--primary-light, #f0f6ff);
+    font-weight: 600;
+    color: var(--primary-dark, #003b8e);
+}
+
+.glossary-table td a {
+    color: var(--primary-dark, #003b8e);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.glossary-table td a:hover,
+.glossary-table td a:focus {
+    text-decoration: underline;
+}
+
+.glossary-tag {
+    display: inline-block;
+    margin-top: 0.75rem;
+    padding: 0.2rem 0.75rem;
+    border-radius: 999px;
+    background: #edf2ff;
+    color: #193778;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.lead {
+    font-size: 1.1rem;
+    color: #42526e;
+    max-width: 720px;
+}
+
+.glossary-entry {
+    max-width: 920px;
+    margin: 0 auto 4rem;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.glossary-entry section {
+    background: #f9fbff;
+    border: 1px solid #dce6ff;
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 6px 16px rgba(25, 55, 120, 0.08);
+}
+
+.glossary-entry section h3 {
+    margin-top: 0;
+    color: #193778;
+}
+
+.glossary-entry__back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--primary-dark, #003b8e);
+    text-decoration: none;
+}
+
+.glossary-entry__back:hover,
+.glossary-entry__back:focus {
+    text-decoration: underline;
+}
+
+.glossary-entry__names {
+    margin: 0;
+    line-height: 1.6;
+    color: #42526e;
+}
+
+.glossary-entry .glossary-tag {
+    margin-top: 0;
+    align-self: flex-start;
+}
+
+.glossary-entry p {
+    margin-top: 0.75rem;
+    margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+    .glossary-entry {
+        gap: 1.25rem;
+    }
+
+    .glossary-entry section {
+        padding: 1.25rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .glossary-table {
+        min-width: 100%;
+    }
+
+    .lead {
+        font-size: 1rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add a styled glossary overview table with links to dedicated term pages
- create detailed glossary articles for each term including definitions, guidance for officials, and examples
- extend shared styles and capture glossary source data in a new JSON file

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68cdd78cdb6c832ca53b38188357c011