### PR TITLE
Add glossary pages and styling

### DIFF
--- a/slovnicek.html
+++ b/slovnicek.html
@@ -80,12 +80,12 @@
     <div>
       <section class="main-content glossary-overview">
         <h2>Slovníček</h2>
-        <p>Vybrané pojmy z oblasti regulace a řízení systémů umělé inteligence podle AI Actu a souvisejících metodik.
-          Každý z nich má vlastní stránku s detailním vysvětlením, praktickým kontextem pro veřejnou správu a příkladem
-          využití.</p>
+        <p>Přehled základních pojmů ze světa umělé inteligence – od klíčových technologií a principů přes metodické
+          výrazy až po role a povinnosti definované v AI Actu. Každý termín má vlastní stránku s odbornou definicí,
+          srozumitelným vysvětlením pro úředníky a příkladem využití ve veřejné správě.</p>
         <div class="table-wrapper">
           <table class="glossary-table">
-            <caption>Hlavní pojmy používané v katalogu a v rámci AI Actu.</caption>
+            <caption>Glosář pojmů, se kterými se na portálu využití AI ve veřejném sektoru nejčastěji pracuje.</caption>
             <thead>
               <tr>
                 <th scope="col">Preferovaný název</th>
@@ -94,51 +94,280 @@
             </thead>
             <tbody>
               <tr>
-                <th scope="row"><a href="slovnicek/system-umele-inteligence.html">Systém umělé inteligence</a></th>
+                <th scope="row"><a href="slovnicek/umela-inteligence.html">umělá inteligence</a></th>
                 <td>
-                  <span class="glossary-chip">Legální definice</span>
-                  <p>Strojový systém fungující s různou mírou autonomie, který vytváří výstupy ovlivňující fyzické nebo
-                    digitální prostředí.</p>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Umělá inteligence (anglicky AI – Artificial Intelligence) označuje oblast vědy, která se zabývá tvorbou strojů vykazujících známky inteligentního chování.</p>
                 </td>
               </tr>
               <tr>
-                <th scope="row"><a href="slovnicek/ai-act.html">AI Act (Nařízení o umělé inteligenci)</a></th>
+                <th scope="row"><a href="slovnicek/automatizace.html">automatizace</a></th>
                 <td>
-                  <span class="glossary-chip">Legislativa EU</span>
-                  <p>Nařízení (EU) 2024/1689 stanovující jednotná pravidla pro vývoj, uvádění na trh a využívání systémů
-                    umělé inteligence v Evropské unii.</p>
+                  <p>Automatizace je proces nahrazování nebo zjednodušování lidských činností stroji či technologiemi.</p>
                 </td>
               </tr>
               <tr>
-                <th scope="row"><a href="slovnicek/poskytovatel-ai-systemu.html">Poskytovatel AI systému</a></th>
+                <th scope="row"><a href="slovnicek/natural-language-processing-nlp.html">Natural Language Processing (NLP) (zpracování přirozeného jazyka)</a></th>
                 <td>
-                  <span class="glossary-chip">Role podle AI Act</span>
-                  <p>Organizace, která vyvine nebo dá vyvinout AI systém a uvádí ho na trh pod svým jménem; odpovídá za
-                    plnění povinností stanovených nařízením.</p>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Zpracování přirozeného jazyka (anglicky Natural Language Processing, NLP) je interdisciplinární obor na pomezí lingvistiky a informatiky (umělé inteligence).</p>
                 </td>
               </tr>
               <tr>
-                <th scope="row"><a href="slovnicek/nasazujici-subjekt.html">Nasazující subjekt</a></th>
+                <th scope="row"><a href="slovnicek/strojove-uceni.html">strojové učení</a></th>
                 <td>
-                  <span class="glossary-chip">Role podle AI Act</span>
-                  <p>Úřad nebo jiná organizace, která systém umělé inteligence používá v praxi a zajišťuje dohled,
-                    transparentnost a informování dotčených osob.</p>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Strojové učení je podoblast umělé inteligence, která se zaměřuje na algoritmy a modely umožňující počítačovým systémům zlepšovat své chování na základě dat a zkušeností namísto explicitního naprogramování.</p>
                 </td>
               </tr>
               <tr>
-                <th scope="row"><a href="slovnicek/vysokorizikovy-ai-system.html">Vysokorizikový AI systém</a></th>
+                <th scope="row"><a href="slovnicek/hluboke-uceni.html">hluboké učení</a></th>
                 <td>
-                  <span class="glossary-chip">Klasifikace rizika</span>
-                  <p>Systém zahrnutý v přílohách AI Actu, jehož fungování může výrazně ovlivnit bezpečnost nebo základní
-                    práva a vyžaduje přísnější opatření.</p>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Hluboké učení (anglicky deep learning) je typ strojového učení založený na umělých neuronových sítích s mnoha vrstvami (odtud &quot;hluboké&quot;).</p>
                 </td>
               </tr>
               <tr>
-                <th scope="row"><a href="slovnicek/regulacni-sandbox.html">Regulační sandbox pro AI</a></th>
+                <th scope="row"><a href="slovnicek/expertni-system.html">expertní systém</a></th>
                 <td>
-                  <span class="glossary-chip">Podpůrný nástroj</span>
-                  <p>Kontrolované prostředí pro testování inovativních AI řešení pod dohledem dozorového orgánu před jejich
-                    plným nasazením.</p>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Expertní systém je počítačový program navržený tak, aby poskytoval odborné rady či rozhodnutí v určité specifické oblasti na úrovni lidského experta.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/pocitacove-videni.html">počítačové vidění</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Počítačové vidění je oblast umělé inteligence, která se zaměřuje na umožnění počítačům interpretovat a chápat vizuální svět (obrázky a videa) podobně jako člověk.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/inteligentni-agent.html">inteligentní agent</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Inteligentní agent je autonomní entita (softwarová nebo hardwarová), která vnímá své okolní prostředí senzory a na základě toho v prostředí jedná pomocí aktuátorů tak, aby dosáhla svých cílů.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/chatbot.html">chatbot</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Chatbot je počítačový program navržený pro simulaci přirozené konverzace s uživatelem.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/large-language-model-llm.html">Large Language Model (LLM) (velký jazykový model)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Velký jazykový model (Large Language Model, LLM) je pokročilý model zpracování přirozeného jazyka s velmi velkým počtem parametrů, trénovaný na rozsáhlých objemech textových dat.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/large-multimodal-model-lmm.html">Large Multimodal Model (LMM) (velký multimodální model)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Velký multimodální model (LMM) je model umělé inteligence, který dokáže zpracovávat a generovat více než jeden typ dat (neboli modality), typicky kombinaci textu a dalších médií (např.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/token.html">token</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Token v kontextu zpracování jazyka představuje sekvenci znaků (typicky část slova, celé slovo nebo znak) považovanou za jednotku textu pro model AI.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/vektor.html">vektor</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Vektor v AI kontextu označuje seznam čísel (uspořádanou číselnou reprezentaci), který slouží k matematickému vyjádření datového prvku.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/vektorova-databaze.html">vektorová databáze</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Vektorová databáze je specializovaný úložný systém navržený pro ukládání a vyhledávání dat ve formě vektorových reprezentací.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/embedding.html">embedding (vnoření)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Embedding (česky vnoření) označuje transformaci nějakého objektu (slova, věty, obrázku apod.) do podoby číselného vektoru tak, aby tento vektor zachycoval klíčové vlastnosti či význam původního objektu.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/use-case.html">use case (případ užití)</a></th>
+                <td>
+                  <p>Use case znamená konkrétní scénář nebo způsob využití technologie či systému k dosažení určitého cíle.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/black-box.html">black box (černá skříňka)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Pojem &quot;black box&quot; (černá skříňka) označuje systém nebo model, u něhož nejsou z vnějšího pohledu srozumitelné vnitřní mechanismy rozhodování.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/turinguv-stroj.html">Turingův stroj</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Turingův stroj je teoretický model počítače, který vymyslel britský matematik Alan Turing.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/kavovy-test.html">kávový test</a></th>
+                <td>
+                  <p>Kávový test je neformální zkouška navržená spoluzakladatelem Apple Stevem Wozniakem, která má prověřit skutečnou obecnou inteligenci robota.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/captcha-completely-automated-public-turing-test-to-tell-computers-and-humans-apart.html">CAPTCHA (Completely Automated Public Turing test to tell Computers and Humans Apart) (CAPTCHA)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>CAPTCHA je automatizovaný test typu challenge-response, jehož cílem je odlišit lidského uživatele od počítačového programu (bota).</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/zpetnovazebni-smycka.html">zpětnovazební smyčka</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Zpětnovazební smyčka je proces, při kterém se výstupy systému vracejí zpět na vstup a ovlivňují další chování systému.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/uceni-s-ucitelem.html">učení s učitelem</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Učení s učitelem (supervised learning) je přístup strojového učení, při kterém model trénujeme na trénovacích datech obsahujících vstupy i správné výstupy (tzv.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/uceni-bez-ucitele.html">učení bez učitele</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Učení bez učitele (unsupervised learning) je typ strojového učení, kdy model trénuje na neoznačených datech – nemá předem dané správné odpovědi.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/prompt.html">prompt</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Prompt v prostředí generativní AI označuje vstupní instrukci nebo otázku, kterou uživatel zadá modelu umělé inteligence, aby vyvolal požadovanou odpověď či výsledek.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/prompt-engineering.html">prompt engineering (inženýrství promptů)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Inženýrství promptů (anglicky prompt engineering) je postup a disciplína spočívající v navrhování, testování a optimalizaci vstupních dotazů (promptů) pro generativní modely AI tak, aby tyto modely poskytovaly co nejlepší a nejpřesnější výstupy.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/neuronova-sit.html">neuronová síť</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Umělá neuronová síť je výpočetní model inspirovaný strukturou a fungováním biologických neuronů v mozku.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/generative-ai.html">generative AI (generativní AI)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Generativní umělá inteligence označuje takové modely AI, které jsou navrženy k vytváření nového obsahu – ať už psaného textu, obrázků, hudby či jiných médií – na základě naučených vzorů z trénovacích dat.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/bias-algorithmic-bias.html">bias (algorithmic bias) (bias (algoritmická předpojatost))</a></th>
+                <td>
+                <span class="glossary-chip">společenský fenomén</span>
+                  <p>V kontextu AI znamená pojem bias systémovou odchylku nebo zkreslení v chování modelu, které vyplývá z nevhodných či nevyvážených trénovacích dat nebo ze zaujatosti v návrhu algoritmu.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/explainable-ai-xai.html">Explainable AI (XAI) (vysvětlitelná AI)</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Vysvětlitelná umělá inteligence (XAI, z angl.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/retrieval-augmented-generation-rag.html">Retrieval-Augmented Generation (RAG) (RAG (retrieval-augmented generation))</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>RAG (Retrieval-Augmented Generation) je metoda, která kombinuje velký generativní jazykový model s externí znalostní databází, aby se zvýšila aktuálnost a přesnost jeho odpovědí.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/trenovaci-data.html">trénovací data</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Trénovací data jsou datová sada, na které se AI model učí.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/testovaci-data.html">testovací data</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Testovací data jsou samostatná datová sada použitá k ověření výkonu a generalizačních schopností AI modelu po natrénování.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/algoritmus.html">algoritmus</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Algoritmus je přesný postup nebo návod, kterým lze vyřešit daný typ úlohy krok za krokem.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/halucinace-ai.html">halucinace AI</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Halucinace v kontextu AI označuje jev, kdy model umělé inteligence (zejména velký jazykový model) generuje výrok či odpověď, která zní přesvědčivě a sebevědomě, avšak není pravdivá ani fakticky podložená.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/digitalni-asistent.html">digitální asistent</a></th>
+                <td>
+                <span class="glossary-chip">technický pojem</span>
+                  <p>Digitální (virtuální) asistent je AI aplikace, která pomáhá uživateli komunikovat se zařízením a plnit různé úkoly prostřednictvím přirozené konverzace.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/poskytovatel.html">poskytovatel</a></th>
+                <td>
+                <span class="glossary-chip">legální definice</span>
+                  <p>„Poskytovatel“ je v kontextu AI Act definován jako fyzická nebo právnická osoba, orgán veřejné moci, agentura nebo jiný subjekt, který vyvíjí nebo nechá vyvinout systém umělé inteligence za účelem jeho uvedení na trh nebo do provozu pod svým jménem nebo ochrannou známkou, a to ať už za úplatu nebo zdarma.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/evropsky-urad-pro-umelou-inteligenci.html">Evropský úřad pro umělou inteligenci</a></th>
+                <td>
+                <span class="glossary-chip">legální definice</span>
+                  <p>Evropský úřad pro umělou inteligenci (European AI Office) je nově zřízený orgán v rámci Evropské komise, který slouží jako centrum odborných znalostí pro oblast umělé inteligence v EU.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/zavadejici-subjekt.html">zavádějící subjekt</a></th>
+                <td>
+                <span class="glossary-chip">legální definice</span>
+                  <p>„Zavádějící subjekt“ (deployer) je dle AI Act jakákoli fyzická nebo právnická osoba, orgán veřejné moci, agentura nebo jiný subjekt, který používá systém umělé inteligence ve výkonu své činnosti nebo pravomoci (mimo osobní neprofesionální činnost).</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/dovozce.html">dovozce</a></th>
+                <td>
+                <span class="glossary-chip">legální definice</span>
+                  <p>„Dovozce“ je podle AI Act každá fyzická nebo právnická osoba usazená v EU, která uvede na unijní trh systém umělé inteligence pocházející od poskytovatele ze třetí země.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/distributor.html">distributor</a></th>
+                <td>
+                <span class="glossary-chip">legální definice</span>
+                  <p>„Distributor“ je dle AI Act každý subjekt v dodavatelském řetězci (usazený v EU), který zpřístupňuje systém umělé inteligence na trhu, aniž by sám byl poskytovatelem nebo dovozcem.</p>
                 </td>
               </tr>
             </tbody>

--- a/slovnicek.html
+++ b/slovnicek.html
@@ -78,8 +78,72 @@
 
   <main id="main">
     <div>
-      <section class="main-content">
+      <section class="main-content glossary-overview">
         <h2>Slovníček</h2>
+        <p>Vybrané pojmy z oblasti regulace a řízení systémů umělé inteligence podle AI Actu a souvisejících metodik.
+          Každý z nich má vlastní stránku s detailním vysvětlením, praktickým kontextem pro veřejnou správu a příkladem
+          využití.</p>
+        <div class="table-wrapper">
+          <table class="glossary-table">
+            <caption>Hlavní pojmy používané v katalogu a v rámci AI Actu.</caption>
+            <thead>
+              <tr>
+                <th scope="col">Preferovaný název</th>
+                <th scope="col">Definice a označení</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row"><a href="slovnicek/system-umele-inteligence.html">Systém umělé inteligence</a></th>
+                <td>
+                  <span class="glossary-chip">Legální definice</span>
+                  <p>Strojový systém fungující s různou mírou autonomie, který vytváří výstupy ovlivňující fyzické nebo
+                    digitální prostředí.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/ai-act.html">AI Act (Nařízení o umělé inteligenci)</a></th>
+                <td>
+                  <span class="glossary-chip">Legislativa EU</span>
+                  <p>Nařízení (EU) 2024/1689 stanovující jednotná pravidla pro vývoj, uvádění na trh a využívání systémů
+                    umělé inteligence v Evropské unii.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/poskytovatel-ai-systemu.html">Poskytovatel AI systému</a></th>
+                <td>
+                  <span class="glossary-chip">Role podle AI Act</span>
+                  <p>Organizace, která vyvine nebo dá vyvinout AI systém a uvádí ho na trh pod svým jménem; odpovídá za
+                    plnění povinností stanovených nařízením.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/nasazujici-subjekt.html">Nasazující subjekt</a></th>
+                <td>
+                  <span class="glossary-chip">Role podle AI Act</span>
+                  <p>Úřad nebo jiná organizace, která systém umělé inteligence používá v praxi a zajišťuje dohled,
+                    transparentnost a informování dotčených osob.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/vysokorizikovy-ai-system.html">Vysokorizikový AI systém</a></th>
+                <td>
+                  <span class="glossary-chip">Klasifikace rizika</span>
+                  <p>Systém zahrnutý v přílohách AI Actu, jehož fungování může výrazně ovlivnit bezpečnost nebo základní
+                    práva a vyžaduje přísnější opatření.</p>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/regulacni-sandbox.html">Regulační sandbox pro AI</a></th>
+                <td>
+                  <span class="glossary-chip">Podpůrný nástroj</span>
+                  <p>Kontrolované prostředí pro testování inovativních AI řešení pod dohledem dozorového orgánu před jejich
+                    plným nasazením.</p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   </main>
@@ -96,8 +160,8 @@
         <section class="footer-block">
           <h3>Informace</h3>
           <p><a href="podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
-          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
-              rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
         </section>
         <section class="footer-block">
           <h3>Kontakty</h3>
@@ -105,11 +169,9 @@
           <ul class="footer-social">
             <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
                 rel="noreferrer nofollow">Facebook</a></li>
-            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank"
-                rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
             <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
-            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a>
-            </li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
             <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
                 rel="noreferrer nofollow">LinkedIn</a></li>
           </ul>
@@ -125,7 +187,7 @@
             <img src="logos/dia_logo.svg" alt="DIA logo">
           </div>
           <div class="footer-block">
-            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
               digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
               financovaného Evropskou unií NextGeneration.</p>
             <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
@@ -133,7 +195,7 @@
         </div>
       </section>
       <div class="footer-bottom">
-        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
       </div>
     </div>
   </footer>

--- a/slovnicek/ai-act.html
+++ b/slovnicek/ai-act.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Act (Nařízení o umělé inteligenci) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">Legislativa EU</p>
+          <h2>AI Act</h2>
+          <p class="glossary-entry__alt-name">Česky: Nařízení o umělé inteligenci</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>AI Act je nařízení (EU) 2024/1689 Evropského parlamentu a Rady stanovující harmonizovaná pravidla pro vývoj,
+            uvádění na trh a využívání systémů umělé inteligence v Evropské unii. Zavádí povinnosti pro jednotlivé role v
+            životním cyklu AI, klasifikaci systémů podle rizika a opatření na ochranu základních práv.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Nařízení je přímo použitelné ve všech členských státech a vytváří rámec, který musí veřejná správa respektovat při
+            nákupu, vývoji i provozu AI. Ukládá například povinnost provádět posouzení dopadů na základní práva, plnit
+            požadavky na dokumentaci a transparentnost a registrovat vybrané vysokorizikové systémy.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Před spuštěním automatizovaného systému pro přidělování sociálních dávek musí úřad posoudit, zda spadá mezi
+            vysokorizikové systémy podle AI Actu. Pokud ano, zajistí registraci, vytvoří dokumentaci o řízení rizik a
+            nastaví dohled člověka nad rozhodnutím, aby splnil povinnosti nařízení.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank" rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/algoritmus.html
+++ b/slovnicek/algoritmus.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>algoritmus – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>algoritmus</h2>
+          <p class="glossary-entry__alt-name">Anglicky: algorithm</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Algoritmus je přesný postup nebo návod, kterým lze vyřešit daný typ úlohy krok za krokem. V informatice se algoritmus typicky vyjadřuje ve formě sekvence instrukcí či pravidel pro zpracování vstupních dat a dosažení požadovaného výsledku. Algoritmy mohou být jednoduché (např. recept na seřazení čísel) nebo velmi komplexní (např. algoritmus pro trénování neuronové sítě).</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Jednoduše řečeno, algoritmus je &quot;recept&quot; pro počítač, jak má něco udělat. Je to seznam kroků. Když budete mít algoritmus na upečení dortu, budou tam kroky jako: 1) smíchej mouku, cukr a vejce, 2) předehřej troubu, 3) nalij těsto do formy, atd. Počítačové algoritmy dělají to samé, jen místo dortu řeší výpočetní problémy – ale princip je stejný: přesný soupis kroků k cíli.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Známým algoritmem je třeba Eukleidův algoritmus pro nalezení největšího společného dělitele dvou čísel. Ten říká: dokud se ta dvě čísla nerovnají, nahraď to větší z nich rozdílem obou čísel; nakonec budeš mít největšího dělitele. To je konkrétní příklad jasně daného postupu – algoritmu.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/automatizace.html
+++ b/slovnicek/automatizace.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>automatizace – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <h2>automatizace</h2>
+          <p class="glossary-entry__alt-name">Anglicky: automation</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Automatizace je proces nahrazování nebo zjednodušování lidských činností stroji či technologiemi. V praxi to znamená využití samočinných řídicích systémů k ovládání zařízení a procesů, typicky za účelem zvýšení efektivity, přesnosti a rychlosti prováděných úkolů.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Automatizace znamená, že rutinní nebo opakované úkoly místo lidí vykonávají stroje nebo počítačové programy. Cílem je, aby práce probíhala rychleji a s menší chybovostí – například výrobní linka, kde robotické rameno samo montuje díly, místo aby to dělal člověk ručně.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Běžným příkladem automatizace je termostat, který automaticky zapíná a vypíná topení podle nastavené teploty, nebo robotická linka v továrně, kde roboti skládají produkty bez přímého zásahu člověka.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/bias-algorithmic-bias.html
+++ b/slovnicek/bias-algorithmic-bias.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>bias (algorithmic bias) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">společenský fenomén</p>
+          <h2>bias (algorithmic bias)</h2>
+          <p class="glossary-entry__alt-name">Česky: bias (algoritmická předpojatost)</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>V kontextu AI znamená pojem bias systémovou odchylku nebo zkreslení v chování modelu, které vyplývá z nevhodných či nevyvážených trénovacích dat nebo ze zaujatosti v návrhu algoritmu. Algoritmický bias se projevuje tak, že model dává přednost nebo znevýhodňuje určité skupiny nebo vlastnosti (např. pohlaví, etnikum) bez legitimního důvodu, pouze na základě vzorů v datech. Důsledkem mohou být nespravedlivé či diskriminační rozhodnutí AI systému.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Bias znamená, že AI má v sobě nějaký &quot;skrytý předsudek&quot;. Například pokud naučíme model z dat, kde byly určité skupiny lidí opomíjeny nebo vykresleny negativně, model to přejme. Pak může třeba překladač automaticky překládat slovo &quot;doktor&quot; v mužském rodě a &quot;sestra&quot; v ženském, i když to není univerzálně pravda – protože v trénovacích textech to tak častěji bylo. Bias je problém, kdy AI není nestranná, ale nakloněná jedním směrem kvůli datům.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Face-recognition AI (rozpoznávání obličejů) bylo vytrénováno hlavně na fotkách světlých tváří, a pak hůře rozpoznávalo tváře lidí s tmavší pletí – to je reálný příklad biasu, kdy model měl výrazně vyšší chybovost pro jednu skupinu lidí kvůli nevyváženým datům.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/black-box.html
+++ b/slovnicek/black-box.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>black box – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>black box</h2>
+          <p class="glossary-entry__alt-name">Česky: černá skříňka (black box)</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Pojem &quot;black box&quot; (černá skříňka) označuje systém nebo model, u něhož nejsou z vnějšího pohledu srozumitelné vnitřní mechanismy rozhodování. U AI se tak označují např. složité modely (jako hluboké neuronové sítě), kde víme, jaké vstupy jdou dovnitř a jaké výstupy ven, ale je obtížné vysvětlit, proč model dal konkrétní výsledek. Black-box modely tedy postrádají transparentnost ohledně svého vnitřního fungování.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Řekneme-li o nějaké AI, že je to &quot;černá skříňka&quot;, myslíme tím, že nevíme, co se uvnitř ní přesně děje. Vidíme jen, co do ní dáme a co z ní vyleze, ale nerozumíme tomu, jak k tomu výsledku dospěla. Je to podobné, jako kdybyste měli zázračnou krabičku: zmáčknete tlačítko (vstup) a vypadne odpověď (výstup), ale netušíte, jak to uvnitř spočítala.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Složitá neuronová síť, která rozhoduje o poskytnutí úvěru, může být pro bankéře &quot;černou skříňkou&quot; – oni vidí jen doporučení schválit či zamítnout úvěr, ale nedokáží jednoduše vysvětlit, proč k takovému rozhodnutí AI došla.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/captcha-completely-automated-public-turing-test-to-tell-computers-and-humans-apart.html
+++ b/slovnicek/captcha-completely-automated-public-turing-test-to-tell-computers-and-humans-apart.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CAPTCHA (Completely Automated Public Turing test to tell Computers and Humans Apart) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>CAPTCHA (Completely Automated Public Turing test to tell Computers and Humans Apart)</h2>
+          <p class="glossary-entry__alt-name">Česky: CAPTCHA</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>CAPTCHA je automatizovaný test typu challenge-response, jehož cílem je odlišit lidského uživatele od počítačového programu (bota). Typická CAPTCHA úloha vyžaduje, aby uživatel provedl něco, co je pro člověka snadné, ale pro stroj obtížné – např. opsal zkreslený text z obrázku, identifikoval objekty na několika fotografiích nebo vyřešil jednoduchý vizuální úkol. Používá se jako bezpečnostní opatření na webových stránkách k zamezení automatizovaného spamu či zneužívání služeb.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>CAPTCHA je ta otravná &quot;kontrola, zda nejste robot&quot; na internetu. Třeba vám ukáže obrázek s rozmazanými písmeny a vy je musíte opsat, nebo zaškrtnout všechna políčka, kde je semafor. Pro člověka je to snadné, ale pro automatický program těžké. Takže tím web zjistí, že u počítače sedí člověk a ne robot.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Když se registrujete do nové e-mailové služby, může vás to na konci požádat o vyřešení CAPTCHA – například přepsat písmena z deformovaného obrázku – abyste dokázali, že nejste automatický skript pokoušející se hromadně zakládat účty.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/chatbot.html
+++ b/slovnicek/chatbot.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>chatbot – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>chatbot</h2>
+          <p class="glossary-entry__alt-name">Česky: chatbot</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Chatbot je počítačový program navržený pro simulaci přirozené konverzace s uživatelem. Využívá technologie zpracování přirozeného jazyka k porozumění dotazům a generování odpovědí. Chatboti mohou fungovat textově (např. v chatovacích oknech) i hlasově a často se využívají pro zákaznickou podporu, informační služby nebo jako virtuální asistenti.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Chatbot je v podstatě program, se kterým si povídáte podobně jako s člověkem. Když mu napíšete nebo řeknete otázku, on odpoví. Je naprogramovaný tak, aby rozuměl běžné řeči a uměl reagovat. Může vám například pomoci na webu s výběrem produktu tím, že se ho v chatu ptáte na informace, a on vám je dává.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Příkladem chatbota je třeba automatický asistent na webových stránkách banky, který odpovídá na dotazy typu &quot;Jak si změním heslo?&quot;. Nebo slavný ChatGPT, se kterým si můžete povídat o čemkoli a on na vaše otázky reaguje souvislými odpověďmi.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/digitalni-asistent.html
+++ b/slovnicek/digitalni-asistent.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>digitální asistent – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>digitální asistent</h2>
+          <p class="glossary-entry__alt-name">Anglicky: digital assistant (virtual assistant)</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Digitální (virtuální) asistent je AI aplikace, která pomáhá uživateli komunikovat se zařízením a plnit různé úkoly prostřednictvím přirozené konverzace. Typicky využívá rozpoznávání hlasu a zpracování přirozeného jazyka k porozumění pokynům a umí reagovat hlasem nebo textem. Příklady digitálních asistentů jsou hlasoví asistenti jako Siri, Alexa nebo Google Asistent, kteří dokáží zodpovídat dotazy, nastavovat upomínky, ovládat chytrá zařízení apod..</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>To je program v telefonu či počítači, se kterým můžete mluvit nebo psát a on vám pomáhá – jako takový elektronický pomocník. Například se zeptáte &quot;Jaké bude dnes počasí?&quot; a on vám odpoví předpověď. Nebo mu řeknete &quot;pusť mi hudbu&quot; a on spustí vaši oblíbenou písničku. Je to, jako byste měli osobního asistenta v digitální podobě, který je stále po ruce.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Siri v iPhonu je digitální asistent: můžete jí hlasem říct &quot;Zavolej mámě&quot; a Siri porozumí a vytočí telefonní číslo maminky. Podobně Alexa od Amazonu vám doma na povel rozsvítí světla nebo objedná něco z internetu. Tyto asistenty rozumějí řeči a reagují na ni.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/distributor.html
+++ b/slovnicek/distributor.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>distributor – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">legální definice</p>
+          <h2>distributor</h2>
+          <p class="glossary-entry__alt-name">Anglicky: distributor</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>„Distributor“ je dle AI Act každý subjekt v dodavatelském řetězci (usazený v EU), který zpřístupňuje systém umělé inteligence na trhu, aniž by sám byl poskytovatelem nebo dovozcem. Distributor tedy přeprodává nebo rozšiřuje AI systém dál ke koncovým uživatelům, ale nezasahuje do jeho návrhu ani ho neimportuje ze třetích zemí. Má však povinnost ověřit, že na systému jsou potřebná označení (např. CE značka) a že k němu existuje požadovaná dokumentace, a nesmí distribuovat systém, o němž ví nebo by měl vědět, že nevyhovuje právním požadavkům.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Distributor je prostředník – není to ten, kdo AI systém vytvořil, ani ten, kdo ho přivezl ze zahraničí, ale ten, kdo ho prostě dál prodává nebo dodává zákazníkům. Například velkoobchod nebo e-shop, který prodává AI software od jiných firem, funguje jako distributor. Musí se ale ujistit, že ten produkt má všechny náležitosti a není vadný z hlediska práva.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Velká IT distribuční firma koupí AI kamerový systém od českého poskytovatele a dodává ho městům po celé EU. Tato firma vystupuje jako distributor – nevyvinula to, ale šíří to na trhu, a musí třeba kontrolovat, že výrobce dodal prohlášení o shodě a označení CE k systému.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/dovozce.html
+++ b/slovnicek/dovozce.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dovozce – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">legální definice</p>
+          <h2>dovozce</h2>
+          <p class="glossary-entry__alt-name">Anglicky: importer</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>„Dovozce“ je podle AI Act každá fyzická nebo právnická osoba usazená v EU, která uvede na unijní trh systém umělé inteligence pocházející od poskytovatele ze třetí země. Dovozce má povinnost zajistit, že dovážený AI systém splňuje požadavky evropské legislativy (podobně jako dovozce zboží ručí za soulad produktu s normami). Dovozce je tedy článkem, který přivádí zahraniční AI systém na trh EU pod svou odpovědností.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Dovozce je ten, kdo přiveze AI systém do EU ze zahraničí a začne ho tu nabízet. Například pokud čínská firma vyvine AI software a evropská firma ho sem dováží a prodává, tak ta evropská firma je dovozcem a musí hlídat, že ten AI systém splňuje evropské předpisy.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Firma sídlící v ČR importuje AI zařízení (např. chytrý zdravotnický přístroj s AI) od výrobce z USA a distribuuje ho po EU – tato česká firma je v roli dovozce a musí zajistit, že zařízení splňuje požadavky Aktu o AI, než ho uvede na trh.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/embedding.html
+++ b/slovnicek/embedding.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>embedding – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>embedding</h2>
+          <p class="glossary-entry__alt-name">Česky: embedding (vnoření)</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Embedding (česky vnoření) označuje transformaci nějakého objektu (slova, věty, obrázku apod.) do podoby číselného vektoru tak, aby tento vektor zachycoval klíčové vlastnosti či význam původního objektu. Výsledný vektor (embedding) leží v mnohorozměrném prostoru, kde lze sémantickou podobnost dvou objektů posuzovat například vzdáleností jejich vektorů – podobné objekty mají vektory blízko u sebe.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Embedding je způsob, jak převést třeba slovo nebo obrázek na čísla, kterým počítač rozumí. Uděláme z něj seznam čísel (vektor), který v sobě nese informace o významu. Například slova &quot;král&quot; a &quot;královna&quot; mají embeddingy (vektory) blízko sebe, protože jsou si významově podobná. Pro počítač je pak snadnější s takovými číselnými reprezentacemi pracovat a porovnávat je.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Slovo &quot;pes&quot; může mít embedding jako vektor 300 čísel, a slovo &quot;kočka&quot; jiný 300-rozměrný vektor. Protože psi a kočky jsou si jako pojmy blízké, bude vzdálenost těchto dvou vektorů menší než třeba vzdálenost vektorů &quot;pes&quot; a &quot;auto&quot;. Vektorové reprezentace (embeddingy) tak zachycují vztahy mezi slovy.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/evropsky-urad-pro-umelou-inteligenci.html
+++ b/slovnicek/evropsky-urad-pro-umelou-inteligenci.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Evropský úřad pro umělou inteligenci – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">legální definice</p>
+          <h2>Evropský úřad pro umělou inteligenci</h2>
+          <p class="glossary-entry__alt-name">Anglicky: European Artificial Intelligence Office</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Evropský úřad pro umělou inteligenci (European AI Office) je nově zřízený orgán v rámci Evropské komise, který slouží jako centrum odborných znalostí pro oblast umělé inteligence v EU. Úřad hraje klíčovou roli při implementaci evropského Aktu o umělé inteligenci – zejména v dohledu nad systémy obecné AI – a podporuje vývoj a používání důvěryhodné AI v souladu s hodnotami EU. Zároveň má Úřad za úkol chránit před riziky spojenými s AI a zajišťovat jednotný a efektivní přístup EU k regulaci a inovacím v AI napříč členskými státy.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Je to speciální úřad na úrovni EU, který se stará o to, aby se umělá inteligence v Evropě rozvíjela bezpečně a férově. Funguje jako hlavní expert a dozor – pomáhá hlídat dodržování pravidel (AI Act), radí vládám členských zemí ohledně AI a podporuje spolupráci a sdílení znalostí. Dá se říct, že je to takový &quot;AI dohledový úřad&quot; pro celou Evropu.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Evropský úřad pro AI například bude sbírat informace o nových velkých AI modelech (jako GPT-4) a posuzovat jejich rizika. Bude také spolupracovat s národními úřady, třeba když někde v EU nastane problém s nebezpečným použitím AI, tento úřad pomůže koordinovat řešení.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/expertni-system.html
+++ b/slovnicek/expertni-system.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>expertní systém – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>expertní systém</h2>
+          <p class="glossary-entry__alt-name">Anglicky: expert system</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Expertní systém je počítačový program navržený tak, aby poskytoval odborné rady či rozhodnutí v určité specifické oblasti na úrovni lidského experta. Typicky obsahuje bázi znalostí (souhrn pravidel a faktů daného oboru) a inferenční stroj, který z těchto znalostí a zadaných vstupů odvodí závěry nebo doporučení pro daný problém.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Jde o chytrý program, který napodobuje myšlení odborníka v nějaké oblasti. Má v sobě uložené znalosti (pravidla a fakta) jako by měl člověk v hlavě, a umí podle nich radit nebo rozhodovat. Takový systém může třeba lékařům pomáhat s diagnostikou – do programu se zadají symptomy pacienta a on navrhne, jaká nemoc to může být, podobně jako by to udělal zkušený doktor.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Klasickým příkladem expertního systému byl systém MYCIN z 70. let, který lékařům pomáhal diagnostikovat bakteriální infekce a doporučoval vhodná antibiotika na základě zadaných příznaků a laboratorních výsledků.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/explainable-ai-xai.html
+++ b/slovnicek/explainable-ai-xai.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Explainable AI (XAI) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>Explainable AI (XAI)</h2>
+          <p class="glossary-entry__alt-name">Česky: vysvětlitelná AI</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Vysvětlitelná umělá inteligence (XAI, z angl. Explainable AI) je přístup k AI kladoucí důraz na to, aby modely a jejich rozhodnutí byly pro lidi srozumitelné a mohli jsme pochopit důvody, proč AI k určitému výsledku došla. Cílem XAI je vyvinout takové modely nebo metody (např. LIME, SHAP, heatmapy pro neur. sítě), které umožní nahlédnout do vnitřního fungování AI &quot;černých skříněk&quot; a vysvětlit jejich rozhodovací procesy. To zvyšuje důvěru uživatelů v AI a umožňuje odhalit případné chyby či bias.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Vysvětlitelná AI znamená, že AI není jako neprostupná magie, ale že dokáže ukázat a zdůvodnit, proč udělala to, co udělala. Například místo aby jen řekla &quot;nepovolím ti půjčku&quot;, vysvětlitelná AI by mohla dodat: &quot;protože tvůj příjem je nízký a už máš jiný úvěr&quot;. Jsou to metody, jak udělat rozhodování AI průhlednější. Díky tomu mohou lidé AI více věřit a taky si všimnout, když AI někde dělá chybu.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Příklad vysvětlitelné AI: systém pro rozpoznávání obrázků diagnostikuje nemoc z rentgenového snímku a zároveň zvýrazní oblast snímku, která ho k té diagnóze vedla (např. zakroužkuje skvrnu na plicích). Tím lékař vidí, na základě čeho AI usoudila svůj závěr.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/generative-ai.html
+++ b/slovnicek/generative-ai.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>generative AI – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>generative AI</h2>
+          <p class="glossary-entry__alt-name">Česky: generativní AI</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Generativní umělá inteligence označuje takové modely AI, které jsou navrženy k vytváření nového obsahu – ať už psaného textu, obrázků, hudby či jiných médií – na základě naučených vzorů z trénovacích dat. Generativní AI dokáže na vstupní zadání (prompt) vygenerovat originální výstup, který dodržuje kontext a styl požadovaný uživatelem. Příklady generativní AI zahrnují velké jazykové modely (generující text) nebo modely typu GAN a difuzní modely (generující obrazy či zvuk).</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Tohle je druh AI, který něco tvoří. Když mu dáte pokyn, sám vytvoří nové věci – třeba napíše článek, namaluje obrázek nebo složí melodii. Učí se z obrovského množství existujících dat (textů, obrázků), a pak umí generovat podobný obsah. Když například generativní AI viděla milion obrázků koček, dokáže na přání vygenerovat úplně nový obrázek kočky, který vypadá realisticky, i když taková kočka nikdy neexistovala.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>ChatGPT, který vám dokáže napsat originální odpověď nebo povídku, je generativní AI zaměřená na text. Obdobně DALL-E nebo Stable Diffusion jsou generativní modely, které na textový popis (např. &quot;kočka na kole v impresionistickém stylu&quot;) vygenerují nový obrázek odpovídající popisu.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/halucinace-ai.html
+++ b/slovnicek/halucinace-ai.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>halucinace AI – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>halucinace AI</h2>
+          <p class="glossary-entry__alt-name">Anglicky: AI hallucination</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Halucinace v kontextu AI označuje jev, kdy model umělé inteligence (zejména velký jazykový model) generuje výrok či odpověď, která zní přesvědčivě a sebevědomě, avšak není pravdivá ani fakticky podložená. Model si tak obrazně &quot;vymyslí&quot; neexistující fakta nebo nesprávné informace. Halucinace jsou důsledkem statistické povahy generativních modelů – model může vytvořit obsah, který nebyl v trénovacích datech, a nic mu nebrání v tom, aby byl fakticky chybný.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Když AI sebejistě tvrdí něco, co není pravda, říká se tomu halucinace. Například se zeptáte AI: &quot;Kdo vynalezl perpetuum mobile?&quot; a ona odpoví smyšleným, ale uvěřitelně znějícím příběhem s konkrétním jménem vynálezce, rokem a detailem – a přitom je to celé výmysl. AI nemá úmysl lhát, jen sestaví odpověď, která statisticky dává smysl, ale fakticky nesedí.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Uživatel: &quot;Kolik má člověk srdcí?&quot; AI model (halucinace): &quot;Člověk má dvě srdce, jedno pumpuje krev do horní poloviny těla a druhé do dolní.&quot; – Tato odpověď je sebevědomá a zní odborně, ale je naprosto chybná. Model &quot;halucinoval&quot; nepravdivou informaci.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/hluboke-uceni.html
+++ b/slovnicek/hluboke-uceni.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>hluboké učení – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>hluboké učení</h2>
+          <p class="glossary-entry__alt-name">Anglicky: deep learning</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Hluboké učení (anglicky deep learning) je typ strojového učení založený na umělých neuronových sítích s mnoha vrstvami (odtud &quot;hluboké&quot;). Tyto hluboké neuronové sítě se dokáží naučit velmi složité vzory a reprezentace v datech hierarchicky – vyšší vrstvy sítě postupně navazují na výstupy nižších vrstev a umožňují tak počítači porozumět komplexním charakteristikám vstupních dat (např. rozpoznávat objekty na obrázcích či porozumět kontextu vět).</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Hluboké učení využívá umělé &quot;mozky&quot; – neuronové sítě – které mají hodně mezivrstev. Díky nim se počítač učí velmi složité věci. Například dokáže poznat, co je na fotce, nebo překládat věty, protože v těchto vrstvách se naučí rozpoznat tvary, barvy, slova a jejich význam v různých úrovních detailu.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Když dáte počítači tisíce fotek koček a psů a on se je naučí rozlišit, pravděpodobně použil hlubokou neuronovou síť. Takový model pak dokáže správně určit, zda je na nové fotce kočka nebo pes, díky hlubokému učení.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/inteligentni-agent.html
+++ b/slovnicek/inteligentni-agent.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>inteligentní agent – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>inteligentní agent</h2>
+          <p class="glossary-entry__alt-name">Anglicky: intelligent agent</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Inteligentní agent je autonomní entita (softwarová nebo hardwarová), která vnímá své okolní prostředí senzory a na základě toho v prostředí jedná pomocí aktuátorů tak, aby dosáhla svých cílů. Klíčovými vlastnostmi inteligentního agentu jsou autonomie (jedná samostatně bez neustálého dohledu člověka), proaktivita (sleduje cíle) a reaktivita (reaguje na změny prostředí).</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Představte si &quot;virtuálního robota&quot; nebo program, který sám rozhoduje a něco dělá ve svém prostředí. Například automatický vysavač je agent – má senzory (nárazníky, kamery) na vnímání místnosti a aktuátory (kolečka, kartáče) na úklid. Sám se rozhodne kam jet a co uklidit, aby splnil cíl (vyluxovat byt), aniž by ho člověk přímo řídil.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Softwareový agent může být program na burze, který sám analyzuje trh a provádí obchody podle nastaveného cíle (např. maximalizovat zisk). V reálném světě je příkladem agentu třeba autonomní robot v továrně, který se pohybuje po skladě a převáží zboží na základě vlastního vnímání překážek a cílů.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/kavovy-test.html
+++ b/slovnicek/kavovy-test.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>kávový test – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <h2>kávový test</h2>
+          <p class="glossary-entry__alt-name">Anglicky: coffee test</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Kávový test je neformální zkouška navržená spoluzakladatelem Apple Stevem Wozniakem, která má prověřit skutečnou obecnou inteligenci robota. Robot úspěšně projde kávovým testem, pokud dokáže vstoupit do libovolné cizí domácnosti, najít v ní kuchyň a uvařit v ní kávu, aniž by měl předem jakékoli konkrétní instrukce o uspořádání té domácnosti. Na rozdíl od Turingova testu (test inteligence v konverzaci) se kávový test zaměřuje na fyzické a praktické schopnosti umělé obecné inteligence v reálném světě.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Jednoduše: robot by zvládl sám přijít k vám domů a udělat si kafe. Musel by najít kuchyň, najít kávovar, vodu, kávu, hrnek – a připravit kávu, aniž mu někdo napoví, kde co je. To je obrovsky těžký úkol i pro pokročilé roboty, takže kdyby to nějaký zvládl, říkáme, že prošel kávovým testem a je opravdu hodně inteligentní a všestranný.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Zatím neexistuje robot, který by kávový test spolehlivě zvládal. Je to spíše myšlenkový experiment: představme si domácího humanoidního robota, kterému řeknete &quot;udělej mi kávu&quot; a on sám vše najde a připraví – takový robot by splnil kávový test.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/large-language-model-llm.html
+++ b/slovnicek/large-language-model-llm.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Large Language Model (LLM) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>Large Language Model (LLM)</h2>
+          <p class="glossary-entry__alt-name">Česky: velký jazykový model</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Velký jazykový model (Large Language Model, LLM) je pokročilý model zpracování přirozeného jazyka s velmi velkým počtem parametrů, trénovaný na rozsáhlých objemech textových dat. Díky své velikosti a komplexitě dokáže LLM rozumět složitým jazykovým vstupům a generovat souvislé a kontextově relevantní texty. Mezi příklady LLM patří modely jako GPT-4, které vynikají ve vytváření textu na základě zadaných podnětů.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Jedná se o velmi velký počítačový &quot;mozek&quot; na texty. Byl naučen z obrovského množství textů (třeba téměř celého internetu) a díky tomu umí pokračovat v textu nebo odpovídat na otázky tak, že to často zní, jako by psal člověk. Když mu zadáte větu nebo otázku, dovede vygenerovat smysluplnou odpověď, protože má v sobě statisticky odpozorované vzory jazyka.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>ChatGPT je příklad velkého jazykového modelu – když mu položíte otázku v češtině, dokáže vám odpovědět plynule česky, protože byl natrénován na ohromném množství textů a naučil se strukturu a slovní zásobu jazyka.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/large-multimodal-model-lmm.html
+++ b/slovnicek/large-multimodal-model-lmm.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Large Multimodal Model (LMM) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>Large Multimodal Model (LMM)</h2>
+          <p class="glossary-entry__alt-name">Česky: velký multimodální model</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Velký multimodální model (LMM) je model umělé inteligence, který dokáže zpracovávat a generovat více než jeden typ dat (neboli modality), typicky kombinaci textu a dalších médií (např. obrazů či zvuku). Na rozdíl od čistě jazykových modelů (LLM) může LMM přijímat vstupy ve formě textu i obrázků a podle toho vytvářet odpovídající výstupy. Příkladem LMM je model schopný odpovídat na dotazy k obrázku (popíše obsah fotografie apod.).</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Zatímco běžný velký jazykový model pracuje jen s textem, multimodální model umí navíc i obrázky nebo další typy vstupů. Znamená to, že takový model můžete třeba požádat, aby popsal, co je na přiložené fotce, a on to zvládne – protože kromě čtení textu &quot;vidí&quot; i obraz. Je to jako kdyby měl AI model nejen čtenářské schopnosti, ale i oči a uši.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Model GPT-4 ve verzi s vizuálním vstupem je multimodální – uživatel mu může ukázat obrázek (např. fotografii složeného nábytku) a zeptat se, jak ten nábytek smontovat, a model dokáže analyzovat obrázek a poradit.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/nasazujici-subjekt.html
+++ b/slovnicek/nasazujici-subjekt.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nasazující subjekt (deployér AI systému) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">Role podle AI Act</p>
+          <h2>Nasazující subjekt</h2>
+          <p class="glossary-entry__alt-name">Anglicky: AI deployer</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Nasazujícím subjektem je organizace nebo osoba, která využívá systém umělé inteligence pro vlastní účely. U
+            veřejného sektoru jde zejména o úřad, který systém aplikuje v rozhodovací nebo podpůrné agendě. Nasazující subjekt
+            odpovídá za to, že systém používá v souladu s návodem poskytovatele a plní povinnosti související s dohledem,
+            transparentností a informováním dotčených osob.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>I když úřad není autorem technologie, musí u nasazeného systému zajistit školení pracovníků, nastavení dohledu
+            člověka a případně i komunikaci s občany o využívání AI. V případě vysokorizikových systémů se vyžaduje vedení
+            záznamů, sledování výkonu a okamžitá nápravná opatření při zjištění problémů.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Úřad práce využívá algoritmus k vyhodnocování žádostí o rekvalifikace. Ačkoli systém dodal externí poskytovatel,
+            úřad je nasazujícím subjektem – určuje, jak se AI používá, kdo má přístup k výsledkům a jak se o rozhodnutí
+            informují klienti.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank" rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/natural-language-processing-nlp.html
+++ b/slovnicek/natural-language-processing-nlp.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Natural Language Processing (NLP) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>Natural Language Processing (NLP)</h2>
+          <p class="glossary-entry__alt-name">Česky: zpracování přirozeného jazyka</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Zpracování přirozeného jazyka (anglicky Natural Language Processing, NLP) je interdisciplinární obor na pomezí lingvistiky a informatiky (umělé inteligence). Zabývá se analýzou a generováním textu nebo mluvené řeči tak, aby jim počítač rozuměl a dokázal je smysluplně zpracovat. Typickými úlohami NLP jsou například strojový překlad, odpovídání na otázky nebo automatická korektura textu.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>NLP umožňuje počítačům &quot;rozumět&quot; lidskému jazyku. Díky tomu dokážou třeba přeložit větu z jednoho jazyka do druhého, odpovědět na otázku položenou ve větě, nebo zjistit, jestli je napsaný text třeba pozitivní nebo negativní (analýza sentimentu).</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Praktickým příkladem NLP je automatický překladač (například Google Překladač), který převede českou větu do angličtiny, nebo hlasový asistent, který porozumí mluvenému dotazu a poskytne odpověď.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/neuronova-sit.html
+++ b/slovnicek/neuronova-sit.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>neuronová síť – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>neuronová síť</h2>
+          <p class="glossary-entry__alt-name">Anglicky: neural network</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Umělá neuronová síť je výpočetní model inspirovaný strukturou a fungováním biologických neuronů v mozku. Skládá se z umělých neuronů (výpočetních jednotek) propojených váhami. Neuronová síť je obvykle organizována do vrstev: vstupní vrstva přijímá data, jednu či více skrytých vrstev, které data zpracovávají a extrahují z nich příznaky, a výstupní vrstvu, která poskytuje výsledky. Trénování neuronové sítě spočívá v úpravě vah spojení mezi neurony tak, aby síť pro dané vstupy dávala správné výstupy.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Neuronová síť je program složený z mnoha malých propojených výpočetních &quot;uzlů&quot; (neurony), podobně jako je mozek složený z neuronů biologických. Tyto uzly spolu komunikují a ovlivňují se čísly (vahami spojů). Když do sítě pošleme například obrázek (jako sadu čísel), signál postupně prochází sítí a každá vrstva z něj něco &quot;vyzobe&quot; – třeba jedna najde hrany, další tvary – až poslední vrstva řekne výsledek (např. &quot;na obrázku je kočka&quot;).</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Neuronové sítě pohánějí spoustu dnešních AI aplikací. Například rozpoznávání psaného textu (písmen) na poště: obrázek každého psaného směrovacího čísla projde neuronovou sítí, která nakonec vyhodí číslice v digitální podobě. Síť se to naučila z mnoha příkladů ručně psaných čísel.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/pocitacove-videni.html
+++ b/slovnicek/pocitacove-videni.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>počítačové vidění – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>počítačové vidění</h2>
+          <p class="glossary-entry__alt-name">Anglicky: computer vision</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Počítačové vidění je oblast umělé inteligence, která se zaměřuje na umožnění počítačům interpretovat a chápat vizuální svět (obrázky a videa) podobně jako člověk. Zahrnuje metody pro zpracování a analýzu digitálních obrazů za účelem rozpoznávání objektů, detekce událostí či získávání informací z vizuálních dat. Pomocí trénovacích dat se modely počítačového vidění naučí identifikovat konkrétní objekty v obrazech a vyhodnocovat jejich význam v kontextu.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Počítačové vidění umožňuje počítačům &quot;dívat se&quot; na obrázky nebo video a rozumět, co na nich je. Například díky tomu dokáže mobil rozpoznat vaši tvář, když ho odemykáte, nebo samořiditelné auto vidí, kde je na silnici překážka. Počítač se tohle naučí tak, že mu ukážeme spoustu obrázků s popisem, co na nich je, a on si zapamatuje vzory.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Typickým příkladem počítačového vidění je funkce &quot;rozpoznání obličeje&quot; na fotografiích – software pozná, kde na fotce jsou obličeje lidí a dokáže je třeba automaticky označit nebo zaostřit. Dalším příkladem je systém v samořídicím autě, který pomocí kamer identifikuje jízdní pruhy, chodce či dopravní značky.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/poskytovatel-ai-systemu.html
+++ b/slovnicek/poskytovatel-ai-systemu.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Poskytovatel AI systému – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">Role podle AI Act</p>
+          <h2>Poskytovatel AI systému</h2>
+          <p class="glossary-entry__alt-name">Anglicky: AI provider</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Poskytovatelem je fyzická nebo právnická osoba, která vyvine nebo dá vyvinout systém umělé inteligence a uvede ho na
+            trh či do provozu pod svým jménem nebo ochrannou známkou. Nese odpovědnost za splnění povinností nařízení, včetně
+            řízení rizik, dokumentace a technických opatření.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Veřejná instituce se může stát poskytovatelem, pokud vyvíjí vlastní systém, nebo pokud zásadně upraví komerčně
+            dodaný produkt. Poskytovatel musí vést technickou dokumentaci, zajistit kvalitu dat, vybudovat systém řízení
+            rizik a umožnit auditování. Tyto povinnosti nelze přesunout pouze na dodavatele.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Krajský úřad zadá vývoj AI nástroje pro predikci dopravních nehod a následně ho provozuje pod vlastní značkou.
+            Přestože část řešení dodal externí dodavatel, poskytovatelem je úřad. Musí proto zpracovat dokumentaci, nastavit
+            procesy kontroly kvality a zajistit, aby nástroj plnil požadavky AI Actu.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank" rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/poskytovatel.html
+++ b/slovnicek/poskytovatel.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>poskytovatel – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">legální definice</p>
+          <h2>poskytovatel</h2>
+          <p class="glossary-entry__alt-name">Anglicky: provider</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>„Poskytovatel“ je v kontextu AI Act definován jako fyzická nebo právnická osoba, orgán veřejné moci, agentura nebo jiný subjekt, který vyvíjí nebo nechá vyvinout systém umělé inteligence za účelem jeho uvedení na trh nebo do provozu pod svým jménem nebo ochrannou známkou, a to ať už za úplatu nebo zdarma. Poskytovatel tedy nese primární odpovědnost za uvedení AI systému na trh a za soulad systému s právními požadavky.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Poskytovatel je jednoduše ten, kdo AI systém vytvoří a nabízí ho dál (prodává nebo poskytuje). Například firma, která vyvine software s umělou inteligencí a dá ho na trh pod svou značkou, je poskytovatelem toho AI systému.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Příklad: Společnost vyvinula AI aplikaci pro rozpoznávání obličeje a nabízí ji dalším firmám – v rámci zákona je tato společnost poskytovatelem AI systému.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/prompt-engineering.html
+++ b/slovnicek/prompt-engineering.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>prompt engineering – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>prompt engineering</h2>
+          <p class="glossary-entry__alt-name">Česky: inženýrství promptů</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Inženýrství promptů (anglicky prompt engineering) je postup a disciplína spočívající v navrhování, testování a optimalizaci vstupních dotazů (promptů) pro generativní modely AI tak, aby tyto modely poskytovaly co nejlepší a nejpřesnější výstupy. Zahrnuje techniky, jak formulovat instrukce, dávat modelu kontext, příklady nebo jiná vodítka v promptu, aby model porozuměl úloze a vygeneroval požadovaný výsledek. Prompt engineering se stal důležitým zejména s nástupem velkých jazykových modelů, kde drobné změny v zadání mohou výrazně ovlivnit kvalitu odpovědi.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Jde o umění a techniku, jak správně &quot;mluvit&quot; na AI model. Když chcete od chytrého modelu dostat dobrou odpověď, musíte mu umět chytře položit otázku – a to není vždy triviální. Prompt engineering znamená vymýšlet nejlepší možnou formulaci dotazu: třeba přidat kontext, rozdělit složitý úkol na více částí nebo uvést příklad, aby model pochopil, co přesně po něm chceme. Je to vlastně takové šperkování zadání pro AI.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Řekněme, že chcete od AI recept na dort. Jednoduchý prompt by mohl být &quot;Dej mi recept na čokoládový dort.&quot; Ale prompt engineering by ho vylepšil: &quot;Jsi šéfcukrář. Napiš prosím podrobný recept na nadýchaný čokoládový dort s polevou, včetně seznamu surovin a kroků, v bodech.&quot; – takový promyšlený prompt pravděpodobně přinese lepší strukturovanou odpověď.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/prompt.html
+++ b/slovnicek/prompt.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>prompt – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>prompt</h2>
+          <p class="glossary-entry__alt-name">Česky: prompt</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Prompt v prostředí generativní AI označuje vstupní instrukci nebo otázku, kterou uživatel zadá modelu umělé inteligence, aby vyvolal požadovanou odpověď či výsledek. Prompt je formulován v přirozeném jazyce (případně s určitými zvláštními značkami či klíčovými slovy) a kvalita a formulace promptu zásadně ovlivňuje kvalitu generovaného výstupu modelu.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Prompt je jednoduše to, co napíšete (nebo řeknete) AI modelu, aby něco udělal. Je to vaše zadání. Když používáte třeba ChatGPT, prompt je ta věta nebo otázka, kterou mu položíte. Model pak na základě promptu vygeneruje odpověď. Když prompt změníte nebo upřesníte, dostanete jinou odpověď – proto je důležité umět prompt správně formulovat.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Příkladem promptu může být: &quot;Napiš tříodstavcový dopis s žádostí o omluvu z jednání, formálním stylem.&quot; – to je instrukce, na kterou model vygeneruje výsledný dopis. Pokud by byl prompt jednoduše &quot;omluva z jednání&quot;, model by nemusel pochopit detaily formy, proto se prompty obvykle formulují co nejjasněji.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/regulacni-sandbox.html
+++ b/slovnicek/regulacni-sandbox.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Regulační sandbox pro AI – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">Podpůrný nástroj</p>
+          <h2>Regulační sandbox pro AI</h2>
+          <p class="glossary-entry__alt-name">Anglicky: AI regulatory sandbox</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Regulační sandbox je kontrolované prostředí, které umožňuje testovat inovativní AI řešení pod dohledem dozorových
+            orgánů. AI Act podporuje vznik národních sandboxů, v nichž lze zkoušet projekty, které ještě nejsou plně v souladu
+            s veškerými požadavky, ale mají vysoký společenský přínos.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Sandbox poskytuje bezpečný rámec pro experimenty: účastníkům se vymezí podmínky, rozsah dat, dozor a doba trvání.
+            Úřad získá možnost testovat inovaci s reálnými daty, přičemž regulatorní orgán průběžně sleduje rizika a pomáhá
+            doplňovat potřebná opatření, aby projekt mohl později fungovat v ostrém provozu.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Ministerstvo zdravotnictví chce vyzkoušet diagnostickou AI pro analýzu rentgenů. V rámci národního sandboxu se
+            domluví s dozorem na omezeném pilotu v jedné nemocnici. Projekt má jasně stanovené metriky kvality, postup
+            anonymizace dat a harmonogram vyhodnocení. Po skončení sandboxu získá podklady pro regulérní nasazení.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank" rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/retrieval-augmented-generation-rag.html
+++ b/slovnicek/retrieval-augmented-generation-rag.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retrieval-Augmented Generation (RAG) – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>Retrieval-Augmented Generation (RAG)</h2>
+          <p class="glossary-entry__alt-name">Česky: RAG (retrieval-augmented generation)</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>RAG (Retrieval-Augmented Generation) je metoda, která kombinuje velký generativní jazykový model s externí znalostní databází, aby se zvýšila aktuálnost a přesnost jeho odpovědí. Při RAG přístupu model nejprve dostane k dotazu uživatele relevantní informace vyhledané v databázi znalostí (retrieval) a teprve poté generuje finální odpověď s odkazem na tyto dodatečné informace. Tím se překonává omezení jazykových modelů, které by jinak odpovídaly jen na základě statických dat ze svého tréninku – RAG umožňuje zahrnout aktuální či specializované znalosti bez nutnosti model přeučovat.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>RAG je způsob, jak přimět AI nejdříve si něco dohledat a pak odpovědět. Když se AI na něco zeptáte, tak se nejprve podívá do nějaké knihovny nebo databáze, najde si k tématu informace, a teprve pak z nich složí odpověď. Díky tomu může odpovídat podle nejnovějších nebo přesných dat, i když je sama neznávala. Je to, jako kdyby se nejdřív poradila s encyklopedií a pak vám odpověděla.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Pokud položíte AI dotaz &quot;Co je hlavním městem Bhútánu?&quot; a použije se RAG, model napřed prohledá znalostní bázi (třeba aktualizovanou Wikipedii) a zjistí &quot;hlavní město Bhútánu je Thimphu&quot; a pak vygeneruje odpověď: &quot;Hlavním městem Bhútánu je Thimphu.&quot; Tím je zajištěno, že odpověď vychází z aktuálních dat.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/strojove-uceni.html
+++ b/slovnicek/strojove-uceni.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>strojové učení – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>strojové učení</h2>
+          <p class="glossary-entry__alt-name">Anglicky: machine learning</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Strojové učení je podoblast umělé inteligence, která se zaměřuje na algoritmy a modely umožňující počítačovým systémům zlepšovat své chování na základě dat a zkušeností namísto explicitního naprogramování. Model se během trénování učí odhalovat vzory v datech a následně dokáže predikovat či rozhodovat i o nových vstupních datech.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Jde o to, že počítač se z příkladů sám naučí, jak řešit nějaký úkol. Nedáme mu tedy přesná pravidla, ale ukážeme mu spoustu dat (např. obrázky koček a psů s popisky) a on se naučí rozpoznávat, co je kočka a co pes. Čím více dat a zpětné vazby dostane, tím lepší v daném úkolu je.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Například filtrování nevyžádané pošty (spamu) ve vašem e-mailu využívá strojové učení – systém se naučil z mnoha příkladů emailů, které byly označeny jako spam nebo ne, a podle toho dokáže nové e-maily automaticky roztřídit.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/system-umele-inteligence.html
+++ b/slovnicek/system-umele-inteligence.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Systém umělé inteligence – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">Legální definice</p>
+          <h2>Systém umělé inteligence</h2>
+          <p class="glossary-entry__alt-name">Anglicky: AI system</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>AI Act definuje systém umělé inteligence jako strojový systém navržený pro autonomní fungování, který generuje
+            výstupy v podobě obsahu, předpovědí, doporučení či rozhodnutí ovlivňujících fyzické nebo virtuální prostředí.
+            Může využívat různé metody strojového učení, logiky či znalostních přístupů a je navržen tak, aby se během
+            provozu přizpůsoboval či optimalizoval.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Termín zahrnuje jak pokročilé modely strojového učení, tak expertní systémy nebo generativní modely. Klíčovým
+            znakem je, že systém na základě dat a instrukcí vytváří výstupy, které mohou podporovat rozhodování úřadu
+            nebo být využity pro automatizované úkony. Do definice se vejde i služba nakoupená jako cloudový produkt, pokud
+            úřad využívá její algoritmické schopnosti.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Finanční správa využije nástroj, který analyzuje transakční data a upozorní na neobvyklé vzorce u DPH přiznání.
+            Systém samostatně vyhodnocuje rizika, navrhuje podezřelé případy a průběžně se upravuje podle doplňujících
+            informací od analytiků. Takové řešení je typickým příkladem systému umělé inteligence ve smyslu nařízení.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank" rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/testovaci-data.html
+++ b/slovnicek/testovaci-data.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>testovací data – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>testovací data</h2>
+          <p class="glossary-entry__alt-name">Anglicky: test data</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Testovací data jsou samostatná datová sada použitá k ověření výkonu a generalizačních schopností AI modelu po natrénování. Model testovací data předtím při učení neviděl. Testovací sada obsahuje typově stejná data jako tréninková (např. vstupy a odpovídající správné výstupy), ale slouží výhradně k měření toho, jak dobře si model vede na nových příkladech. Výsledky modelu na testovacích datech indikují, zda se model nepřeučil (nenaučil se jen nazpaměť trénovací příklady) a jakou má reálnou přesnost či chybu.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>To je sada příkladů, kterou si schováme bokem a nepoužijeme ji při učení. Až AI naučíme na trénovacích datech, dáme jí tyhle nové testovací příklady, abychom viděli, jestli opravdu umí řešit obecně ten úkol, nebo se jen naučila zpaměti trénovací data. Když model na testovacích datech uspěje, znamená to, že se naučil princip a ne jen nazpaměť konkrétní případy.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Uvažujme opět model na rozpoznávání psů a koček. Trénujeme ho na určité sadě fotek psů a koček, ale pak ho otestujeme na jiných fotkách psů a koček, které během učení neviděl (to jsou testovací data). Pokud si vede dobře i na nich, test dopadl úspěšně – model se to naučil obecně.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/token.html
+++ b/slovnicek/token.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>token – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>token</h2>
+          <p class="glossary-entry__alt-name">Česky: token</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Token v kontextu zpracování jazyka představuje sekvenci znaků (typicky část slova, celé slovo nebo znak) považovanou za jednotku textu pro model AI. Jazykové modely pracují s textem právě na úrovni tokenů – například slovo &quot;kočka&quot; může být jedním tokenem, zatímco složené slovo nebo věta se rozdělí na více tokenů. Tokenizace je proces převodu textu do posloupnosti tokenů, se kterými pak model operuje.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Token je jednoduše řečeno kousek textu, se kterým pracuje AI model. Model si totiž věty nejprve rozřeže na malé části – tokeny. Někdy je jeden token celé slovo (u krátkých slov jako &quot;a&quot;, &quot;pes&quot;), jindy jen část slova (u delších nebo složených slov). Počítač pak už nevidí text jako písmenka, ale jako sérii těchto tokenů – čísel, která je reprezentují.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Věta &quot;Kočka leze dírou&quot; by se při tokenizaci mohla rozdělit na tokeny [&quot;Kočka&quot;, &quot;le&quot;, &quot;ze&quot;, &quot; &quot;, &quot;dí&quot;, &quot;rou&quot;] v závislosti na použité metodě. Model pak zpracovává tuto sekvenci tokenů místo původního textu.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/trenovaci-data.html
+++ b/slovnicek/trenovaci-data.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>trénovací data – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>trénovací data</h2>
+          <p class="glossary-entry__alt-name">Anglicky: training data</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Trénovací data jsou datová sada, na které se AI model učí. V případě učení s učitelem obsahují vstupy a k nim přiřazené správné výstupy (označení), které slouží jako vzor, podle nějž model své parametry přizpůsobuje. Kvalita a reprezentativnost trénovacích dat zásadně ovlivňuje schopnost modelu generalizovat – model se z nich snaží pochopit obecné vzory, aby mohl správně reagovat i na nové, dříve neviděné vstupy.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>To jsou ta data, kterými AI &quot;krmíme&quot; při učení. Představují příklady, ze kterých se model učí. Když chceme naučit AI rozeznávat psy a kočky, trénovací data budou stovky fotek psů (označené jako &quot;pes&quot;) a stovky fotek koček (označené &quot;kočka&quot;). Model je prožene a nastaví si podle nich své vnitřní parametry. Čím lepší a rozmanitější trénovací data jsou, tím líp se model naučí.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Trénovací data pro překladatelský model mohou být tisíce vět v angličtině a jejich oficiální překlady do češtiny. Model je na těchto dvojicích vět natrénován, aby se naučil překládat.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/turinguv-stroj.html
+++ b/slovnicek/turinguv-stroj.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Turingův stroj – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>Turingův stroj</h2>
+          <p class="glossary-entry__alt-name">Anglicky: Turing machine</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Turingův stroj je teoretický model počítače, který vymyslel britský matematik Alan Turing. Slouží k formálnímu popisu algoritmů a výpočetních procesů v teorii vyčíslitelnosti. Klasický Turingův stroj se skládá z nekonečné pásky rozdělené na buňky (které fungují jako paměť) a řídicí jednotky se seznamem pravidel. Řídicí jednotka může na pásce číst symboly, zapisovat je a posouvat pásku doleva nebo doprava podle předem daných pravidel (programu). Přestože je to abstrakce, Turingův stroj dokáže modelovat jakýkoli algoritmus, a je proto základním konceptem teoretické informatiky.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Je to myšlenkový model počítače. Představte si nekonečně dlouhou pásku papíru (paměť) a jednoduchého robota, který po ní jezdí, umí číst políčka na pásce, psát na ně a posunovat se. Robot má přesný seznam instrukcí, co má dělat v různých situacích. To je Turingův stroj. I když takový stroj fyzicky neexistuje, pomáhá nám pochopit, co počítače teoreticky dokážou spočítat.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Turingův stroj je teoretický, takže nemá konkrétní praktický příklad jako zařízení. Můžeme ho ale přirovnat k velmi jednoduchému počítači: například proužek papíru s čísly a člověk s tužkou, který podle přesných instrukcí postupně ta čísla maže a zapisuje další – to by byla manuální simulace Turingova stroje.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/uceni-bez-ucitele.html
+++ b/slovnicek/uceni-bez-ucitele.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>učení bez učitele – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>učení bez učitele</h2>
+          <p class="glossary-entry__alt-name">Anglicky: unsupervised learning</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Učení bez učitele (unsupervised learning) je typ strojového učení, kdy model trénuje na neoznačených datech – nemá předem dané správné odpovědi. Snaží se v datech nalézt skryté struktury, podobnosti nebo rozdělení do skupin. Typickými úlohami učení bez učitele jsou shlukování (clustering), kdy model rozdělí data do skupin s podobnými vlastnostmi, nebo hledání anomálií (detekce odlehlých hodnot).</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Tady se počítač učí sám, bez toho aniž bychom mu řekli, jak vypadá správná odpověď. Představme si krabici s mixem ovoce a zeleniny. Modelu jen ukážeme všechny obrázky, ale neřekneme, co je co. Model začne hledat, co je si podobné – třeba zjistí, že má dvě hlavní skupiny: kulaté červené věci (jablka a rajčata) a zelené podlouhlé věci (okurky a banány) atd. Prostě sám v datech najde skupiny či vzory, aniž by věděl jejich jména či správné odpovědi.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Učení bez učitele se používá třeba pro zákaznickou segmentaci: firma vezme data o svých zákaznících (bez jakýchkoli štítků) a nechá algoritmus, aby sám rozdělil zákazníky do skupin s podobným chováním (například jedna skupina často nakupuje levné zboží, jiná skupina drahé zboží sporadicky atd.).</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/uceni-s-ucitelem.html
+++ b/slovnicek/uceni-s-ucitelem.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>učení s učitelem – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>učení s učitelem</h2>
+          <p class="glossary-entry__alt-name">Anglicky: supervised learning</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Učení s učitelem (supervised learning) je přístup strojového učení, při kterém model trénujeme na trénovacích datech obsahujících vstupy i správné výstupy (tzv. označená data). Model postupně upravuje své parametry tak, aby pro dané vstupy produkoval co nejpřesněji požadované výstupy. Supervizované učení se používá např. pro klasifikaci (model se učí z příkladů přiřazovat vstupům kategorie) či regresi (predikci číselné hodnoty).</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Tohle je učení stylem &quot;s předlohou&quot;. Představte si, že učíte počítač rozpoznávat ovoce: ukazujete mu obrázek jablka a řeknete &quot;tohle je jablko&quot;, pak obrázek hrušky a řeknete &quot;tohle je hruška&quot;, a tak dál pro spoustu obrázků. Počítač (model) má u každého obrázku i tu správnou odpověď (to je ten &quot;učitel&quot;) a podle toho se ladí, aby příště u nového obrázku dokázal správně říct, co na něm je.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Příkladem učení s učitelem je trénování emailového filtru spamu: vezmeme tisíce emailů označených jako &quot;spam&quot; nebo &quot;nespam&quot; a tímto označením (učitelem) učíme model rozlišovat, do které kategorie nové emaily patří.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/umela-inteligence.html
+++ b/slovnicek/umela-inteligence.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>umělá inteligence – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>umělá inteligence</h2>
+          <p class="glossary-entry__alt-name">Anglicky: artificial intelligence</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Umělá inteligence (anglicky AI – Artificial Intelligence) označuje oblast vědy, která se zabývá tvorbou strojů vykazujících známky inteligentního chování. V informatice se UI někdy definuje jako inteligentní agent, tedy zařízení, které vnímá své prostředí a podniká kroky k úspěšnému dosažení stanovených cílů.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Jinými slovy, jde o to, aby počítače dokázaly dělat &quot;chytré&quot; úkoly podobně jako lidé – například se učit, rozhodovat nebo řešit problémy. Dnes se s umělou inteligencí setkáváme běžně, třeba v mobilních telefonech (fotografování s pomocí AI, hlasoví asistenti Siri či Google Asistent) nebo při automatickém rozpoznávání obličeje pro odemknutí zařízení.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Například personalizované doporučování filmů na internetu nebo asistent v telefonu, který rozumí hlasovým povelům, jsou projevy umělé inteligence v praxi.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/use-case.html
+++ b/slovnicek/use-case.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>use case – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <h2>use case</h2>
+          <p class="glossary-entry__alt-name">Česky: use case (případ užití)</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Use case znamená konkrétní scénář nebo způsob využití technologie či systému k dosažení určitého cíle. Jde o popis, jak uživatel nebo organizace může prakticky použít dané řešení v reálné situaci. V oblasti IT a AI se pojem use case používá k ilustraci aplikace technologie – např. use case umělé inteligence ve státní správě může být automatická klasifikace dokumentů na úřadě.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Je to vlastně příklad toho, k čemu se něco používá. Když se řekne &quot;use case&quot; nějaké technologie, myslí se tím konkrétní případ, jak tu technologii využít. Například pro AI ve zdravotnictví může být use case &quot;automatické vyhodnocení rentgenových snímků&quot; – tedy konkrétní způsob, jak tam AI pomáhá.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Use case pro chatbot ve veřejné správě: elektronický asistent na webu úřadu, který odpovídá občanům na časté dotazy (například jak požádat o nový pas). To je konkrétní případ užití AI chatbota v praxi.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/vektor.html
+++ b/slovnicek/vektor.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>vektor – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>vektor</h2>
+          <p class="glossary-entry__alt-name">Anglicky: vector</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Vektor v AI kontextu označuje seznam čísel (uspořádanou číselnou reprezentaci), který slouží k matematickému vyjádření datového prvku. Modely strojového učení převádějí vstupy jako slova, obrázky či jiná data do vektorů tak, aby s nimi mohly efektivně počítat. Například slovo může být reprezentováno vektorem reálných čísel (embedding), kde každé číslo nese určitou informaci o znacích či významu slova v daném kontextu.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Vektor si můžeme představit jako řadu čísel, něco jako souřadnice. Pro počítač je vše číslo, a tak i složitější věci (slovo, fotku) převede na sadu čísel – vektor. Když má třeba AI rozlišit obrázky koček a psů, každý obrázek nejprve převede na vektor čísel (např. popisující různé rysy obrázku) a podle těchto čísel pak rozhoduje.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Slovo &quot;král&quot; může být v jazykovém modelu reprezentováno vektorem, například [0.25, -0.14, 0.88, ...] (mnohodimenzionální bod v prostoru). Podobně obrázek 28x28 pixelů (např. číslice) lze chápat jako vektor 784 čísel (světelnost jednotlivých pixelů) pro účely výpočtů neuronové sítě.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/vektorova-databaze.html
+++ b/slovnicek/vektorova-databaze.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>vektorová databáze – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>vektorová databáze</h2>
+          <p class="glossary-entry__alt-name">Anglicky: vector database</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Vektorová databáze je specializovaný úložný systém navržený pro ukládání a vyhledávání dat ve formě vektorových reprezentací. Umožňuje efektivně uchovávat vektorové reprezentace (embeddingy) objektů a poskytuje operace, jako je vyhledání nejbližších sousedů – tedy najít v databázi vektory nejpodobnější zadanému vektoru. V praxi se vektorové databáze používají například pro vyhledávání podobných obrázků či dokumentů na základě jejich vektorového vyjádření obsahu.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Je to databáze, která neukládá jen běžné tabulky s čísly a texty, ale hlavně dlouhé seznamy čísel – vektory. Díky tomu se v ní dá rychle najít třeba obrázek, který je nejpodobnější jinému obrázku, nebo text s podobným významem jako zadaný text. Vektorová databáze je optimalizovaná na takovéto &quot;podobnostní&quot; vyhledávání podle významu, ne jen podle přesné shody slov.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Pokud máme vektorovou databázi s embeddingy receptů (každý recept reprezentovaný vektorem podle obsahu), můžeme do ní zadat vektor reprezentující například &quot;těstoviny s rajčaty&quot; a databáze nám vrátí recepty, které jsou tomuto vektoru (tomuto jídlu) nejblíže – tedy podobná jídla.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/vysokorizikovy-ai-system.html
+++ b/slovnicek/vysokorizikovy-ai-system.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vysokorizikový AI systém – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">Klasifikace rizika</p>
+          <h2>Vysokorizikový AI systém</h2>
+          <p class="glossary-entry__alt-name">Anglicky: High-risk AI system</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>AI Act za vysokorizikové označuje systémy uvedené v přílohách II a III nařízení, protože mohou významně ovlivnit
+            bezpečnost osob, základní práva nebo kritickou infrastrukturu. Patří sem například systémy používané ve veřejné
+            správě pro rozhodování o přístupu k dávkám, vzdělání nebo zdravotní péči.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Pokud úřad plánuje nasadit systém, který spadá do jedné z kategorií přílohy III (např. hodnocení bonity nebo
+            přiznávání sociálních dávek), musí splnit soubor povinností – od registrace v evropském databázovém systému, přes
+            zavedení řízení rizik a kvalitní data, až po dohled člověka a transparentní komunikaci s občany.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Městský úřad používá AI k vyhodnocení žádostí o obecní byty. Systém automaticky doporučuje priority žadatelů a
+            používá citlivé osobní údaje. Nařízení jej řadí mezi vysokorizikové, proto musí mít auditovatelné modely, záznamy o
+            provozu a jasně popsaný proces lidského schvalování výsledků.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank" rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/zavadejici-subjekt.html
+++ b/slovnicek/zavadejici-subjekt.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>zavádějící subjekt – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">legální definice</p>
+          <h2>zavádějící subjekt</h2>
+          <p class="glossary-entry__alt-name">Anglicky: deployer (user of an AI system)</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>„Zavádějící subjekt“ (deployer) je dle AI Act jakákoli fyzická nebo právnická osoba, orgán veřejné moci, agentura nebo jiný subjekt, který používá systém umělé inteligence ve výkonu své činnosti nebo pravomoci (mimo osobní neprofesionální činnost). Deployer je tedy uživatel AI systému v praxi – ten, kdo ho nasazuje do svého procesu či služby a nese odpovědnost za jeho použití v daném kontextu.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Zavádějící subjekt znamená ten, kdo AI skutečně používá ve své práci nebo službách (nasazuje ji). Je to uživatel AI systému v terénu, ne běžný občan pro domácí použití, ale třeba firma nebo úřad, který implementuje AI do svého provozu. Například banka, která využije AI pro posuzování žádostí o úvěr, je zavádějící subjekt – nasadila AI systém do praxe.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Městský úřad začne používat AI nástroj na automatickou analýzu podnětů od občanů. V rámci legislativy EU je tento úřad zavádějícím subjektem, protože nasadil AI systém do své úřední činnosti.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/zpetnovazebni-smycka.html
+++ b/slovnicek/zpetnovazebni-smycka.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>zpětnovazební smyčka – Slovníček | Katalog využití AI ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <article class="glossary-entry">
+        <header class="glossary-entry__header">
+          <p class="glossary-entry__tag">technický pojem</p>
+          <h2>zpětnovazební smyčka</h2>
+          <p class="glossary-entry__alt-name">Anglicky: feedback loop</p>
+        </header>
+        <section>
+          <h3>Co říká definice</h3>
+          <p>Zpětnovazební smyčka je proces, při kterém se výstupy systému vracejí zpět na vstup a ovlivňují další chování systému. Systém tak může na základě vlastní výstupní odezvy upravovat svůj stav nebo chování. V řízení a v AI to umožňuje samoregulaci – například regulator (termostat) porovnává výstup (aktuální teplotu) s požadovanou hodnotou a na základě rozdílu (zpětné vazby) zapíná či vypíná topení.</p>
+        </section>
+        <section>
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Je to kruh: co vyjde ven, to se vrátí dovnitř a ovlivní to, co bude příště. Příklad je termostat – měří teplotu v místnosti (výstup systému – teplota) a podle toho buď zapne nebo vypne topení (zásah do vstupu systému), čímž tu teplotu zase ovlivní. V kontextu AI může jít třeba o situaci, kdy výsledek modelu je znovu použit ke zpřesnění jeho dalšího rozhodování.</p>
+        </section>
+        <section>
+          <h3>Příklad z praxe</h3>
+          <p>Internetové sociální sítě vytvářejí zpětnovazební smyčky: jakmile začnete klikat na určitý typ obsahu, algoritmus vám ho ukazuje více (zpětná vazba), čímž vy ještě více klikáte na podobný obsah a systém se utvrzuje v tom, co vám má servírovat.</p>
+        </section>
+        <nav class="glossary-entry__back">
+          <a href="../slovnicek.html">&larr; Zpět na slovníček</a>
+        </nav>
+      </article>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o&nbsp;přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a></li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v&nbsp;rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v&nbsp;souladu se zákonem č.&nbsp;106/1999&nbsp;Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1459,6 +1459,7 @@ table#table-overview tr>* {
 table#table-overview tr>*:first-child {
     width: 50%;
 }
+
 /* ===== Slovníček ===== */
 .glossary-overview {
     display: flex;

--- a/styles.css
+++ b/styles.css
@@ -1459,3 +1459,153 @@ table#table-overview tr>* {
 table#table-overview tr>*:first-child {
     width: 50%;
 }
+/* ===== Slovníček ===== */
+.glossary-overview {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+    background: #fff;
+    border-radius: 16px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
+}
+
+.glossary-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 480px;
+}
+
+.glossary-table caption {
+    text-align: left;
+    font-weight: 600;
+    padding: 1.25rem 1.5rem 0.5rem;
+    color: var(--text);
+}
+
+.glossary-table thead th {
+    background: var(--secondary);
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.glossary-table th,
+.glossary-table td {
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid #e0e5eb;
+    vertical-align: top;
+}
+
+.glossary-table tbody tr:last-child td,
+.glossary-table tbody tr:last-child th {
+    border-bottom: none;
+}
+
+.glossary-table th a {
+    color: var(--dark);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.glossary-table th a:hover {
+    text-decoration: underline;
+}
+
+.glossary-table td p {
+    margin: 0;
+    line-height: 1.55;
+}
+
+.glossary-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: rgba(32, 115, 21, 0.1);
+    color: var(--dark);
+    border-radius: 999px;
+    padding: 0.25rem 0.75rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.glossary-entry {
+    background: #fff;
+    border-radius: 20px;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    margin-block: 2rem 3rem;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+}
+
+.glossary-entry__header {
+    margin-bottom: 1.75rem;
+}
+
+.glossary-entry__tag {
+    display: inline-flex;
+    align-items: center;
+    background: rgba(32, 115, 21, 0.1);
+    color: var(--dark);
+    padding: 0.3rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+}
+
+.glossary-entry__header h2 {
+    margin: 0;
+    font-size: clamp(1.75rem, 3vw, 2.25rem);
+}
+
+.glossary-entry__alt-name {
+    margin: 0.25rem 0 0;
+    color: #555;
+    font-style: italic;
+}
+
+.glossary-entry section {
+    margin-bottom: 1.75rem;
+}
+
+.glossary-entry section:last-of-type {
+    margin-bottom: 2.5rem;
+}
+
+.glossary-entry__back {
+    border-top: 1px solid #e0e5eb;
+    padding-top: 1.5rem;
+}
+
+.glossary-entry__back a {
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--dark);
+}
+
+.glossary-entry__back a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+    .glossary-table {
+        min-width: 100%;
+    }
+
+    .glossary-table th,
+    .glossary-table td {
+        padding: 0.85rem 1rem;
+    }
+
+    .glossary-entry {
+        margin-block: 1.5rem 2.5rem;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
+    }
+}


### PR DESCRIPTION
## Summary
- create a table-based glossary overview page with links to detailed entries for key AI Act terms
- add individual glossary articles covering definitions, guidance for officials, and examples
- extend the shared stylesheet with glossary-specific table and article styling

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cdd78cdb6c832ca53b38188357c011