### PR TITLE
Add glossary overview and detail pages

### DIFF
--- a/slovnicek.html
+++ b/slovnicek.html
@@ -80,6 +80,61 @@
     <div>
       <section class="main-content">
         <h2>Slovníček</h2>
+        <p class="intro-text">Vybrané pojmy z oblasti využití umělé inteligence ve veřejné správě. Proklikem na jednotlivé
+          položky získáte detailní vysvětlení, praktické tipy i příklady.</p>
+        <div class="table-wrapper">
+          <table class="glossary-table">
+            <thead>
+              <tr>
+                <th scope="col">Preferovaný název</th>
+                <th scope="col">Definice a označení</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row"><a href="slovnicek/algoritmicka-transparentnost.html">Algoritmická transparentnost</a></th>
+                <td>
+                  <p>Schopnost popsat a doložit, jak algoritmus pracuje s daty a jakými kroky dospívá k výsledku.</p>
+                  <span class="glossary-tag">Princip odpovědné AI</span>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/large-language-model.html">Large Language Model (velký jazykový
+                    model)</a></th>
+                <td>
+                  <p>Typ modelu strojového učení schopný zpracovávat a generovat text na základě statistických vzorů
+                    získaných z rozsáhlých datových korpusů.</p>
+                  <span class="glossary-tag">Technický pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/zpracovani-osobnich-udaju.html">Zpracování osobních údajů</a></th>
+                <td>
+                  <p>Jakákoli operace nebo soubor operací s osobními údaji, jako je shromažďování, zaznamenávání,
+                    strukturování či uchování.</p>
+                  <span class="glossary-tag">Legální definice</span>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/data-governance.html">Data Governance (správa dat)</a></th>
+                <td>
+                  <p>Soubor pravidel, rolí a postupů, které zajišťují kvalitní, bezpečné a odpovědné nakládání s daty v
+                    organizaci.</p>
+                  <span class="glossary-tag">Proces řízení</span>
+                </td>
+              </tr>
+              <tr>
+                <th scope="row"><a href="slovnicek/regulatory-sandbox.html">Regulatory Sandbox (regulační
+                    pískoviště)</a></th>
+                <td>
+                  <p>Kontrolované prostředí, ve kterém mohou instituce testovat inovativní technologie za dohledu
+                    regulátora a s dočasně uvolněnými pravidly.</p>
+                  <span class="glossary-tag">Politický nástroj</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   </main>

--- a/slovnicek.json
+++ b/slovnicek.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "algoritmicka-transparentnost",
+    "preferovany_nazev": "Algoritmická transparentnost",
+    "cesky_nazev": "Algoritmická transparentnost",
+    "anglicky_nazev": "Algorithmic transparency",
+    "tag": "Princip odpovědné AI",
+    "definice": "Schopnost popsat a doložit, jak algoritmus pracuje s daty a jakými kroky dospívá k výsledku.",
+    "vysvetleni": "Transparentní postupy usnadňují kontrolu rozhodnutí systémů umělé inteligence a podporují důvěru občanů i vedení úřadu. V praxi to znamená vést dokumentaci o datech, použitých modelech, jejich verzích i o změnách v čase.",
+    "priklad": "Ministerstvo zveřejní stručný popis fungování nástroje, který doporučuje dávky sociální podpory, aby kontrolní orgány i veřejnost rozuměly základním pravidlům, podle nichž se doporučení vytváří."
+  },
+  {
+    "id": "large-language-model",
+    "preferovany_nazev": "Large Language Model",
+    "cesky_nazev": "velký jazykový model",
+    "anglicky_nazev": "Large Language Model",
+    "tag": "Technický pojem",
+    "definice": "Typ modelu strojového učení schopný zpracovávat a generovat text na základě statistických vzorů získaných z rozsáhlých datových korpusů.",
+    "vysvetleni": "Modely jako GPT nebo LLaMA lze využít pro asistenty, sumarizaci dokumentů či návrhy odpovědí. Úředníci by měli vědět, že jde o nástroj, který potřebuje správné zadání a přezkoumání výsledků člověkem.",
+    "priklad": "Úřad práce používá LLM k přípravě návrhů odpovědí na opakující se dotazy veřejnosti. Úředník návrh zkontroluje a doplní o konkrétní informace před odesláním."
+  },
+  {
+    "id": "zpracovani-osobnich-udaju",
+    "preferovany_nazev": "Zpracování osobních údajů",
+    "cesky_nazev": "Zpracování osobních údajů",
+    "anglicky_nazev": "Processing of personal data",
+    "tag": "Legální definice",
+    "definice": "Jakákoli operace nebo soubor operací s osobními údaji, jako je shromažďování, zaznamenávání, strukturování, uchování, přizpůsobení nebo pozměnění.",
+    "vysvetleni": "Každý projekt využívající AI musí mít jasně vymezené, které údaje zpracovává, na základě jakého právního titulu a jak jsou chráněny. Transparentní evidence zpracování je podmínkou souladu s GDPR.",
+    "priklad": "Magistrát vede evidenci všech kroků při zpracování žádostí o sociální služby. Pokud systém AI třídí žádosti podle naléhavosti, zaznamenává se, jaké osobní údaje využívá a jak dlouho jsou uchovávány."
+  },
+  {
+    "id": "data-governance",
+    "preferovany_nazev": "Data Governance",
+    "cesky_nazev": "správa dat",
+    "anglicky_nazev": "Data Governance",
+    "tag": "Proces řízení",
+    "definice": "Soubor pravidel, rolí a postupů, které zajišťují kvalitní, bezpečné a odpovědné nakládání s daty v organizaci.",
+    "vysvetleni": "Dobrá správa dat určuje, kdo je zodpovědný za konkrétní datové sady, jak se schvalují změny a jak se kontroluje kvalita. Bez ní se AI projekty snadno opírají o neaktuální nebo neúplná data.",
+    "priklad": "Krajský úřad zavedl roli správce dat pro oblast dopravy. Ten garantuje, že data o dopravní infrastruktuře jsou pravidelně aktualizována a dostupná pro projekty predikce dopravních kolon." 
+  },
+  {
+    "id": "regulatory-sandbox",
+    "preferovany_nazev": "Regulatory Sandbox",
+    "cesky_nazev": "regulační pískoviště",
+    "anglicky_nazev": "Regulatory Sandbox",
+    "tag": "Politický nástroj",
+    "definice": "Kontrolované prostředí, ve kterém mohou instituce testovat inovativní technologie za dohledu regulátora a s dočasně uvolněnými pravidly.",
+    "vysvetleni": "Sandbox pomáhá úřadům ověřit nové AI služby, aniž by hned musely splnit všechny regulatorní požadavky. Součástí je jasný plán, jak testování vyhodnotit a jak přejít do standardního režimu.",
+    "priklad": "Úřad vyzkoušel chatbot poskytující daňové informace v sandboxu vedeném ministerstvem financí. Po ověření bezpečnosti a kvality odpovědí získal projekt souhlas k rozšíření do ostrého provozu."
+  }
+]

--- a/slovnicek/algoritmicka-transparentnost.html
+++ b/slovnicek/algoritmicka-transparentnost.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Algoritmická transparentnost – Slovníček pojmů</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <a class="term-back-link" href="../slovnicek.html">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
+          </svg>
+          Zpět na přehled pojmů
+        </a>
+        <header class="term-header">
+          <span class="term-label">Princip odpovědné AI</span>
+          <h2>Algoritmická transparentnost</h2>
+          <p class="term-meta"><strong>Český název:</strong> Algoritmická transparentnost</p>
+          <p class="term-meta"><strong>Anglický název:</strong> Algorithmic transparency</p>
+        </header>
+        <section class="term-definition">
+          <h3>Definice</h3>
+          <p>Schopnost popsat a doložit, jak algoritmus pracuje s daty a jakými kroky dospívá k výsledku. Transparentní postupy
+            zahrnují dokumentaci datových zdrojů, použitého modelu, jeho verze a změn, které na něj byly aplikovány.</p>
+        </section>
+        <section class="term-article">
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Transparentnost je klíčová pro důvěru občanů i pro možnost interní kontroly. Pokud dokážete doložit, jak systém
+            pracuje, můžete rychle vysvětlit případné odchylky a upravit model tak, aby neškodil určitým skupinám. Základem je
+            přehledná dokumentace – popis datových sad, účelu jejich použití i odpovědnosti jednotlivých rolí v týmu.</p>
+          <h3>Příklad z praxe</h3>
+          <p>Ministerstvo zveřejní stručný popis fungování nástroje, který doporučuje dávky sociální podpory. Veřejně dostupná
+            příručka vysvětluje, na jaká data se systém dívá, kdo kontroluje jeho výstupy a jak často se model přeučuje. Díky
+            tomu mohou kontrolní orgány i občané snadno zjistit, jak rozhodování probíhá.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/data-governance.html
+++ b/slovnicek/data-governance.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Data Governance – Slovníček pojmů</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <a class="term-back-link" href="../slovnicek.html">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
+          </svg>
+          Zpět na přehled pojmů
+        </a>
+        <header class="term-header">
+          <span class="term-label">Proces řízení</span>
+          <h2>Data Governance (správa dat)</h2>
+          <p class="term-meta"><strong>Preferovaný název:</strong> Data Governance</p>
+          <p class="term-meta"><strong>Český název:</strong> správa dat</p>
+        </header>
+        <section class="term-definition">
+          <h3>Definice</h3>
+          <p>Soubor pravidel, rolí a postupů, které zajišťují kvalitní, bezpečné a odpovědné nakládání s daty v organizaci. Včetně
+            definování odpovědností, kontrol kvality a způsobů sdílení dat.</p>
+        </section>
+        <section class="term-article">
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Bez jasně nastavené správy dat vznikají duplicity, stará data nebo nejasnosti, kdo smí jaké údaje upravovat. Data
+            Governance poskytuje rámec, který stanoví odpovědné osoby, procesy schvalování a metody kontroly kvality. Díky tomu
+            mohou AI projekty stavět na spolehlivých datech.</p>
+          <h3>Příklad z praxe</h3>
+          <p>Krajský úřad jmenoval správce dat pro oblast dopravy. Ten dohlíží na pravidelnou aktualizaci dat o infrastruktuře,
+            dokumentuje změny ve zdrojích a zajišťuje, že jsou data dostupná pro projekty predikce dopravních kolon.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/large-language-model.html
+++ b/slovnicek/large-language-model.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Large Language Model – Slovníček pojmů</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <a class="term-back-link" href="../slovnicek.html">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
+          </svg>
+          Zpět na přehled pojmů
+        </a>
+        <header class="term-header">
+          <span class="term-label">Technický pojem</span>
+          <h2>Large Language Model (velký jazykový model)</h2>
+          <p class="term-meta"><strong>Preferovaný název:</strong> Large Language Model</p>
+          <p class="term-meta"><strong>Český název:</strong> velký jazykový model</p>
+        </header>
+        <section class="term-definition">
+          <h3>Definice</h3>
+          <p>Typ modelu strojového učení schopný zpracovávat a generovat text na základě statistických vzorů získaných z rozsáhlých
+            datových korpusů. Modely jsou trénovány na miliardách slov a dokáží předpovídat pokračování věty nebo vytvořit celý
+            text na základě vstupního zadání.</p>
+        </section>
+        <section class="term-article">
+          <h3>Co to znamená pro úředníky</h3>
+          <p>LLM lze využít k sumarizaci dokumentů, tvorbě konceptů odpovědí, návrhům textů či překladu. Je však nutné brát je jako
+            asistenta – výstupy by vždy měl zkontrolovat člověk, protože model si může informace vymýšlet nebo je poskytnout v
+            nevhodném tónu. Důležitá je také ochrana dat: citlivé informace nepatří do veřejných služeb LLM bez odpovídajících
+            smluvních a technických záruk.</p>
+          <h3>Příklad z praxe</h3>
+          <p>Úřad práce používá velký jazykový model k přípravě návrhů odpovědí na opakující se dotazy veřejnosti. Úředník návrh
+            zkontroluje, doplní specifické údaje a poté jej odešle. Díky tomu se sníží časová náročnost komunikace, aniž by se
+            rezignovalo na lidskou kontrolu.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/regulatory-sandbox.html
+++ b/slovnicek/regulatory-sandbox.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Regulatory Sandbox – Slovníček pojmů</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <a class="term-back-link" href="../slovnicek.html">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
+          </svg>
+          Zpět na přehled pojmů
+        </a>
+        <header class="term-header">
+          <span class="term-label">Politický nástroj</span>
+          <h2>Regulatory Sandbox (regulační pískoviště)</h2>
+          <p class="term-meta"><strong>Preferovaný název:</strong> Regulatory Sandbox</p>
+          <p class="term-meta"><strong>Český název:</strong> regulační pískoviště</p>
+        </header>
+        <section class="term-definition">
+          <h3>Definice</h3>
+          <p>Kontrolované prostředí, ve kterém mohou instituce testovat inovativní technologie za dohledu regulátora a s dočasně
+            uvolněnými pravidly. Testování probíhá podle předem dohodnutého plánu a ve vymezeném čase.</p>
+        </section>
+        <section class="term-article">
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Sandbox umožňuje ověřit nové technologie v bezpečných podmínkách. V rámci dohody s regulátorem získá instituce jasná
+            pravidla, jaké výjimky platí a jak bude měřena úspěšnost. Po skončení testování je nutné vyhodnotit dopady a rozhodnout,
+            zda projekt přejde do běžného režimu.</p>
+          <h3>Příklad z praxe</h3>
+          <p>Úřad vyzkoušel chatbot poskytující daňové informace v sandboxu vedeném ministerstvem financí. Po ověření bezpečnosti,
+            kvality odpovědí a nastavení procesů pro eskalaci složitých dotazů získal projekt souhlas k nasazení do ostrého
+            provozu.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/zpracovani-osobnich-udaju.html
+++ b/slovnicek/zpracovani-osobnich-udaju.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Zpracování osobních údajů – Slovníček pojmů</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content">
+        <a class="term-back-link" href="../slovnicek.html">
+          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" fill="currentColor" />
+          </svg>
+          Zpět na přehled pojmů
+        </a>
+        <header class="term-header">
+          <span class="term-label">Legální definice</span>
+          <h2>Zpracování osobních údajů</h2>
+          <p class="term-meta"><strong>Český název:</strong> Zpracování osobních údajů</p>
+          <p class="term-meta"><strong>Anglický název:</strong> Processing of personal data</p>
+        </header>
+        <section class="term-definition">
+          <h3>Definice</h3>
+          <p>Jakákoli operace nebo soubor operací s osobními údaji, jako je shromažďování, zaznamenávání, strukturování, uchování,
+            přizpůsobení či pozměnění, a to bez ohledu na to, zda je prováděna automatizovaně.</p>
+        </section>
+        <section class="term-article">
+          <h3>Co to znamená pro úředníky</h3>
+          <p>Každý projekt využívající AI musí mít jasně vymezené, které údaje zpracovává a na základě jakého právního titulu.
+            Dokumentujte účely zpracování, retenční dobu i technická opatření na ochranu dat. Bez těchto informací nelze
+            prokázat soulad s GDPR ani odpovědět na dotazy dozorového úřadu.</p>
+          <h3>Příklad z praxe</h3>
+          <p>Magistrát vede evidenci všech kroků při zpracování žádostí o sociální služby. Pokud systém AI třídí žádosti podle
+            naléhavosti, zaznamenává se, jaké osobní údaje využívá, kdo má k datům přístup a jak dlouho jsou uchovávány.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank" rel="noopener noreferrer">Prohlášení
+              o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení digitalizovaných
+              služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy, financovaného Evropskou unií
+              NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1030,6 +1030,123 @@ h3 {
     text-align: justify;
 }
 
+.main-content .intro-text {
+    max-width: 60ch;
+    margin-top: 1rem;
+    margin-bottom: 2rem;
+    color: var(--text-muted);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+.glossary-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+    border: 1px solid var(--border-color-light);
+    box-shadow: var(--card-shadow);
+}
+
+.glossary-table th,
+.glossary-table td {
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--border-color-light);
+    vertical-align: top;
+}
+
+.glossary-table tbody tr:last-child th,
+.glossary-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.glossary-table th {
+    width: 35%;
+    font-weight: 600;
+}
+
+.glossary-table a {
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+.glossary-table a:hover,
+.glossary-table a:focus {
+    text-decoration: underline;
+}
+
+.glossary-table p {
+    margin: 0 0 0.5rem;
+}
+
+.glossary-tag {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    background-color: var(--accent-light);
+    color: var(--accent-dark);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.term-header {
+    margin-bottom: 2rem;
+}
+
+.term-header h2 {
+    margin-bottom: 0.5rem;
+}
+
+.term-label {
+    display: inline-block;
+    margin-bottom: 0.75rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent-dark);
+}
+
+.term-meta {
+    margin: 0 0 0.5rem;
+    color: var(--text-muted);
+}
+
+.term-definition,
+.term-article {
+    margin-bottom: 2.5rem;
+}
+
+.term-definition p,
+.term-article p {
+    margin-bottom: 1rem;
+}
+
+.term-article h3 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.term-back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+.term-back-link svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.term-back-link:hover,
+.term-back-link:focus {
+    text-decoration: underline;
+}
+
 .highlight {
     background: #f9f9f9;
     border-left: 4px solid var(--primary);


### PR DESCRIPTION
## Summary
- add a curated glossary overview table styled in line with the site and link each term to a new detail page
- document glossary source data in a new slovnicek.json file for future updates
- create individual glossary articles with definitions, context for officials, and practical examples

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdd78cdb6c832ca53b38188357c011