### PR TITLE
Add static glossary table and detail pages

### DIFF
--- a/slovnicek.html
+++ b/slovnicek.html
@@ -80,6 +80,83 @@
     <div>
       <section class="main-content">
         <h2>Slovníček</h2>
+        <p>
+          Připravili jsme přehled nejčastěji používaných pojmů v oblasti umělé inteligence ve veřejné správě.
+          V tabulce najdete preferované názvy, stručné definice a typ pojmu. Kliknutím na název se otevře
+          podrobná stránka s vysvětlením a příkladem využití.
+        </p>
+        <div class="glossary-table-wrapper">
+          <table class="glossary-table">
+            <thead>
+              <tr>
+                <th scope="col">Pojem</th>
+                <th scope="col">Definice a typ</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a href="slovnicek/umele-inteligence.html">Umělá inteligence</a>
+                </td>
+                <td>
+                  <p>Soubor metod a systémů, které napodobují nebo rozšiřují schopnosti lidské inteligence
+                    prostřednictvím algoritmů, modelů a dat.</p>
+                  <span class="glossary-tag">základní pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/ai-act.html">Artificial Intelligence Act (Zákon o umělé inteligenci)</a>
+                </td>
+                <td>
+                  <p>Nařízení Evropské unie, které stanovuje pravidla pro vývoj, nasazení a používání systémů
+                    umělé inteligence na jednotném trhu EU.</p>
+                  <span class="glossary-tag">legální definice</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/strojove-uceni.html">Strojové učení</a>
+                </td>
+                <td>
+                  <p>Podmnožina umělé inteligence, která využívá algoritmy k učení se vzorům v datech a
+                    zlepšování výkonu bez explicitního naprogramování všech pravidel.</p>
+                  <span class="glossary-tag">technický pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/sprava-dat.html">Správa dat</a>
+                </td>
+                <td>
+                  <p>Soubor procesů, rolí a politik, které zajišťují kvalitu, bezpečnost a dostupnost dat po
+                    celou dobu jejich životního cyklu.</p>
+                  <span class="glossary-tag">organizační pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/predsudky-v-ai.html">AI Bias (Předsudky v umělé inteligenci)</a>
+                </td>
+                <td>
+                  <p>Systematická odchylka ve výstupech algoritmů, která vzniká vlivem zkreslených dat, modelů nebo
+                    způsobu nasazení a vede k nespravedlivým výsledkům.</p>
+                  <span class="glossary-tag">etický pojem</span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a href="slovnicek/privacy-by-design.html">Privacy by Design (Ochrana soukromí již v návrhu)</a>
+                </td>
+                <td>
+                  <p>Princip tvorby systémů, kdy je ochrana osobních údajů začleněna do návrhu procesů, technologií i
+                    správy dat od samého počátku.</p>
+                  <span class="glossary-tag">právní a etický princip</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
     </div>
   </main>

--- a/slovnicek.json
+++ b/slovnicek.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "umele-inteligence",
+    "preferredName": "Umělá inteligence",
+    "czechName": "Umělá inteligence",
+    "englishName": "Artificial Intelligence",
+    "definition": "Soubor metod a systémů, které napodobují nebo rozšiřují schopnosti lidské inteligence prostřednictvím algoritmů, modelů a dat.",
+    "tag": "základní pojem",
+    "officialExplanation": "Umělá inteligence zahrnuje širokou škálu technologií od pravidlových systémů přes strojové učení až po hluboké neuronové sítě. Ve veřejné správě může pomáhat automatizovat rutinní činnosti, analyzovat velké objemy dat nebo podporovat rozhodování úředníků.",
+    "example": "Například automatizovaný systém pro analýzu digitalizovaných dokumentů, který dokáže rozpoznat typ podání a doporučit další postup zpracování."
+  },
+  {
+    "id": "ai-act",
+    "preferredName": "Artificial Intelligence Act",
+    "czechName": "Zákon o umělé inteligenci",
+    "englishName": "Artificial Intelligence Act",
+    "definition": "Nařízení Evropské unie, které stanovuje pravidla pro vývoj, nasazení a používání systémů umělé inteligence na jednotném trhu EU.",
+    "tag": "legální definice",
+    "officialExplanation": "AI Act zavádí povinnosti pro poskytovatele i uživatele AI podle úrovně rizika. Orgány veřejné správy musí identifikovat, zda jejich systém spadá do kategorie vysokého rizika a zajistit odpovídající dokumentaci, správu dat i dohled.",
+    "example": "Při zavedení systému automatizovaného rozhodování o nároku na sociální dávky musí úřad provést posouzení rizik, vést záznamy o datech a umožnit lidský dohled, aby splnil požadavky AI Act."
+  },
+  {
+    "id": "strojove-uceni",
+    "preferredName": "Strojové učení",
+    "czechName": "Strojové učení",
+    "englishName": "Machine Learning",
+    "definition": "Podmnožina umělé inteligence, která využívá algoritmy k učení se vzorům v datech a zlepšování výkonu bez explicitního naprogramování všech pravidel.",
+    "tag": "technický pojem",
+    "officialExplanation": "Modely strojového učení se trénují na historických datech a následně předpovídají nebo klasifikují nové případy. Ve veřejné správě se používají například pro predikci zatížení pracovišť, kontrolu kvality nebo detekci anomálií.",
+    "example": "Krajský úřad využívá model strojového učení k odhadu počtu žádostí o řidičské průkazy v jednotlivých týdnech a optimalizuje rozvrh úředníků."
+  },
+  {
+    "id": "sprava-dat",
+    "preferredName": "Správa dat",
+    "czechName": "Správa dat",
+    "englishName": "Data Governance",
+    "definition": "Soubor procesů, rolí a politik, které zajišťují kvalitu, bezpečnost a dostupnost dat po celou dobu jejich životního cyklu.",
+    "tag": "organizační pojem",
+    "officialExplanation": "Správa dat je klíčová pro spolehlivost systémů AI. Orgány veřejné správy musí znát původ dat, mít nastavená práva přístupu a pravidelně kontrolovat, zda data odpovídají účelu a právním požadavkům.",
+    "example": "Ministerstvo zavádí katalog datových sad a jasně stanovuje, kdo je správcem údajů potřebných pro algoritmus na vyhodnocování žádostí o dotace."
+  },
+  {
+    "id": "predsudky-v-ai",
+    "preferredName": "AI Bias",
+    "czechName": "Předsudky v umělé inteligenci",
+    "englishName": "AI Bias",
+    "definition": "Systematická odchylka ve výstupech algoritmů, která vzniká vlivem zkreslených dat, modelů nebo způsobu nasazení a vede k nespravedlivým výsledkům.",
+    "tag": "etický pojem",
+    "officialExplanation": "Předsudky mohou způsobovat diskriminaci jednotlivců nebo skupin. Úřady musí monitorovat chování systémů, hodnotit datové sady z hlediska reprezentativnosti a zavádět kontrolní mechanismy pro korekce výsledků.",
+    "example": "Algoritmus pro přidělování sociálních bytů je pravidelně auditován, aby se ověřilo, zda neznevýhodňuje určité věkové nebo etnické skupiny."
+  },
+  {
+    "id": "privacy-by-design",
+    "preferredName": "Privacy by Design",
+    "czechName": "Ochrana soukromí již v návrhu",
+    "englishName": "Privacy by Design",
+    "definition": "Princip tvorby systémů, kdy je ochrana osobních údajů začleněna do návrhu procesů, technologií i správy dat od samého počátku.",
+    "tag": "právní a etický princip",
+    "officialExplanation": "Instituce musí při plánování řešení AI zvažovat minimalizaci zpracování osobních údajů, zavádět pseudonymizaci, auditovatelnost a kontrolu přístupu. Privacy by Design je požadavkem GDPR a podporuje důvěru veřejnosti.",
+    "example": "Při vývoji chatbotu pro komunikaci s občany jsou osobní údaje okamžitě pseudonymizovány a logy se uchovávají jen po dobu nezbytnou pro vyřízení podání."
+  }
+]

--- a/slovnicek/ai-act.html
+++ b/slovnicek/ai-act.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Artificial Intelligence Act – Slovníček | Katalog využití umělé inteligence ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close
+          aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-back" href="../slovnicek.html">&larr; Zpět na Slovníček</a>
+        <h2>Artificial Intelligence Act</h2>
+        <p class="glossary-alt-name">Česky: Zákon o umělé inteligenci</p>
+        <p class="glossary-definition">Nařízení Evropské unie, které stanovuje pravidla pro vývoj, nasazení a používání systémů
+          umělé inteligence na jednotném trhu EU.</p>
+        <span class="glossary-tag">legální definice</span>
+        <section class="glossary-section">
+          <h3>Co pojem znamená</h3>
+          <p>AI Act je první komplexní regulační rámec pro umělou inteligenci na světě. Vymezuje, jaká rizika mohou AI systémy
+            představovat a jaké povinnosti mají jejich dodavatelé i uživatelé. Důraz klade na transparentnost, bezpečnost a
+            ochranu základních práv.</p>
+          <p>Nařízení rozlišuje systémy nepřijatelného rizika, které jsou zakázané, vysokorizikové systémy s přísnými požadavky a
+            méně rizikové aplikace s mírnější regulací. Úřady jsou často v roli uživatelů vysokorizikových systémů, například při
+            automatizaci rozhodování o nárocích občanů.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Před nasazením systému musí orgán veřejné správy určit, zda spadá do kategorie vysokého rizika. Pokud ano, je nutné
+            zajistit správu dat, záznamy o testování, možnost lidského dohledu a poskytovat občanům jasné informace o fungování
+            systému.</p>
+          <p>Doporučuje se vytvořit interní procesy pro hodnocení rizik, pojmenovat odpovědné osoby a udržovat dokumentaci po celou
+            dobu životního cyklu systému. Splnění požadavků AI Act je také důkazem odpovědného přístupu úřadu k novým technologiím.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Příklad z praxe</h3>
+          <p>Při zavádění algoritmu pro posuzování nároku na sociální dávku úřad vytvoří záznam o datech, průběžně monitoruje přesnost
+            modelu a nastaví kontaktní místo, kde občané mohou požádat o lidské přezkoumání rozhodnutí. Tím naplní povinnosti AI
+            Act a posílí důvěru veřejnosti.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a>
+            </li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/predsudky-v-ai.html
+++ b/slovnicek/predsudky-v-ai.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Bias – Slovníček | Katalog využití umělé inteligence ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close
+          aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-back" href="../slovnicek.html">&larr; Zpět na Slovníček</a>
+        <h2>AI Bias</h2>
+        <p class="glossary-alt-name">Česky: Předsudky v umělé inteligenci</p>
+        <p class="glossary-definition">Systematická odchylka ve výstupech algoritmů, která vzniká vlivem zkreslených dat, modelů
+          nebo způsobu nasazení a vede k nespravedlivým výsledkům.</p>
+        <span class="glossary-tag">etický pojem</span>
+        <section class="glossary-section">
+          <h3>Co pojem znamená</h3>
+          <p>Pojem AI Bias označuje situaci, kdy model opakovaně zvýhodňuje či znevýhodňuje určité skupiny lidí. Důvody mohou být v
+            nevyvážených datech, nevhodně navrženém algoritmu nebo v nastavení provozu.</p>
+          <p>Důsledkem může být diskriminace, snížení důvěry veřejnosti a porušení legislativy. Bias je potřeba aktivně sledovat a
+            minimalizovat.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Před nasazením AI je nezbytné analyzovat tréninková data, zda reprezentují všechny relevantní skupiny obyvatel. Úřady by
+            měly nastavit kontrolní mechanismy, které pravidelně vyhodnocují, zda výstupy neobsahují systematické chyby.</p>
+          <p>Součástí řízení biasu je transparentní komunikace, možnost lidského přezkoumání rozhodnutí a zapojení expertů na ochranu
+            práv občanů.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Příklad z praxe</h3>
+          <p>Městský úřad používá systém pro doporučení přidělení sociálních bytů. Každé čtvrtletí provádí audit výstupů a porovnává,
+            zda nejsou určité skupiny dlouhodobě znevýhodněné. Pokud se bias objeví, tým upraví datovou sadu nebo rozhodovací
+            pravidla.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a>
+            </li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/privacy-by-design.html
+++ b/slovnicek/privacy-by-design.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy by Design – Slovníček | Katalog využití umělé inteligence ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close
+          aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-back" href="../slovnicek.html">&larr; Zpět na Slovníček</a>
+        <h2>Privacy by Design</h2>
+        <p class="glossary-alt-name">Česky: Ochrana soukromí již v návrhu</p>
+        <p class="glossary-definition">Princip tvorby systémů, kdy je ochrana osobních údajů začleněna do návrhu procesů,
+          technologií i správy dat od samého počátku.</p>
+        <span class="glossary-tag">právní a etický princip</span>
+        <section class="glossary-section">
+          <h3>Co pojem znamená</h3>
+          <p>Privacy by Design je koncept, který požaduje, aby ochrana soukromí nebyla dodatečným krokem, ale integrální součástí
+            návrhu systému. Každé nové řešení by mělo automaticky minimalizovat sběr osobních údajů a zajistit jejich bezpečné
+            zpracování.</p>
+          <p>Princip vychází z GDPR a podporuje důvěru občanů. Umožňuje předejít problémům s úniky dat nebo s nelegitimním využitím
+            informací.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Při plánování projektu je potřeba zapojit specialisty na ochranu osobních údajů. Ti pomohou nastavit minimální rozsah
+            dat, určit dobu uchovávání a navrhnout bezpečnostní opatření. Veřejná správa má povinnost zohlednit princip Privacy by
+            Design ve všech nových službách.</p>
+          <p>Součástí je i pravidelné testování zabezpečení, dokumentace rozhodnutí a informování občanů, jak jsou jejich data
+            využívána.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Příklad z praxe</h3>
+          <p>Při vývoji konverzačního asistenta úřad rozhodl, že chatovací logy budou okamžitě pseudonymizovány a uchovávány pouze po
+            nezbytně dlouhou dobu. Uživatelé jsou v rozhraní informováni, jaká data se zpracovávají a jak mohou požádat o jejich
+            výmaz.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a>
+            </li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/sprava-dat.html
+++ b/slovnicek/sprava-dat.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Správa dat – Slovníček | Katalog využití umělé inteligence ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close
+          aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-back" href="../slovnicek.html">&larr; Zpět na Slovníček</a>
+        <h2>Správa dat</h2>
+        <p class="glossary-alt-name">English: Data Governance</p>
+        <p class="glossary-definition">Soubor procesů, rolí a politik, které zajišťují kvalitu, bezpečnost a dostupnost dat po
+          celou dobu jejich životního cyklu.</p>
+        <span class="glossary-tag">organizační pojem</span>
+        <section class="glossary-section">
+          <h3>Co pojem znamená</h3>
+          <p>Správa dat pomáhá organizaci pochopit, odkud data pocházejí, kdo je může používat a za jakým účelem. Zahrnuje nastavení
+            pravidel pro sběr, uchovávání, sdílení i mazání dat.</p>
+          <p>V kontextu AI je klíčové mít jistotu, že data jsou aktuální, kompletní a jejich původ je dohledatelný. Bez toho nelze
+            garantovat správné fungování modelů ani jejich auditovatelnost.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Úředníci by měli vědět, kdo je vlastníkem datové sady, jaká oprávnění jsou s ní spojena a jaké jsou zákonné povinnosti.
+            Správa dat zahrnuje také katalogizaci dat a definování odpovědných rolí (například data stewarda).</p>
+          <p>Dobrá správa dat podporuje kvalitu rozhodování a zjednodušuje spolupráci mezi odbory. Umožňuje rychle reagovat na změny
+            v legislativě i na potřebu sdílet data s jinými institucemi.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Příklad z praxe</h3>
+          <p>Ministerstvo zavádí centrální katalog dat. Každá sada má přiřazeného správce, popsaný účel zpracování a pravidelný
+            harmonogram aktualizací. Díky tomu lze data bezpečně použít pro trénink prediktivních modelů.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a>
+            </li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/strojove-uceni.html
+++ b/slovnicek/strojove-uceni.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Strojové učení – Slovníček | Katalog využití umělé inteligence ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close
+          aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-back" href="../slovnicek.html">&larr; Zpět na Slovníček</a>
+        <h2>Strojové učení</h2>
+        <p class="glossary-alt-name">English: Machine Learning</p>
+        <p class="glossary-definition">Podmnožina umělé inteligence, která využívá algoritmy k učení se vzorům v datech a
+          zlepšování výkonu bez explicitního naprogramování všech pravidel.</p>
+        <span class="glossary-tag">technický pojem</span>
+        <section class="glossary-section">
+          <h3>Co pojem znamená</h3>
+          <p>Strojové učení pracuje s daty, na jejichž základě model rozpoznává struktury a dokáže předpovídat výsledek pro nové
+            situace. Využívá se například k třídění dokumentů, odhadu poptávky nebo detekci neobvyklých událostí.</p>
+          <p>Existují různé typy strojového učení – dozorované, nesupervizované či posilované. Každé z nich vyžaduje jiný způsob
+            přípravy dat a ověřování přesnosti.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>Úspěch projektu založeného na strojovém učení závisí na kvalitě dat a průběžném monitoringu výkonu modelu. Úředník by měl
+            vědět, jak byla data očištěna, zda model nezvyšuje riziko diskriminace a jak lze výsledek kontrolovat.</p>
+          <p>Je vhodné vytvořit plán opakovaného přeučování modelu, protože situace se v čase mění. Součástí governance je také
+            dokumentace rozhodovací logiky a jasně definovaná odpovědnost za správu modelu.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Příklad z praxe</h3>
+          <p>Krajský úřad využívá model strojového učení k předpovědi počtu žádostí o řidičský průkaz. Na základě historických dat
+            plánuje směny na přepážkách a předchází přetížení pracoviště.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a>
+            </li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/slovnicek/umele-inteligence.html
+++ b/slovnicek/umele-inteligence.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="cs">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Umělá inteligence – Slovníček | Katalog využití umělé inteligence ve veřejném sektoru</title>
+  <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
+  <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
+  <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
+  <link rel="apple-touch-icon" sizes="180x180" href="https://www.dia.gov.cz/apple-touch-icon.png?v2">
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <a href="#main" class="skip-link">Přeskočit na obsah</a>
+  <header>
+    <div class="header-bar">
+      <button class="hamburger" id="menuBtn" aria-label="Menu" aria-controls="mobile-menu" aria-expanded="false">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+      <h1>
+        <a href="/">
+          <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
+        </a>
+      </h1>
+    </div>
+  </header>
+  <nav class="main-nav" aria-label="Hlavní menu">
+    <div class="main-nav__inner">
+      <ul class="main-nav__list">
+        <li><a href="../project.html">Katalog</a></li>
+        <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../clanky.html">Články</a></li>
+        <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+        <li><a href="../wiki.html">Přidat use case</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div id="mobile-menu" class="mobile-menu" aria-hidden="true">
+    <div class="mobile-menu__overlay" data-mobile-menu-close></div>
+    <div class="mobile-menu__panel" role="dialog" aria-modal="true">
+      <div class="mobile-menu__header">
+        <span>Menu</span>
+        <button class="mobile-menu__close" type="button" data-mobile-menu-close
+          aria-label="Zavřít menu">&times;</button>
+      </div>
+      <nav aria-label="Hlavní menu">
+        <ul class="mobile-menu__list">
+          <li class="mobile-menu__item mobile-menu__item--catalog">
+            <div class="mobile-menu__row">
+              <a href="../project.html">Katalog</a>
+              <button class="mobile-menu__toggle" type="button" aria-expanded="false"
+                aria-controls="mobile-catalog-list">
+                <span class="sr-only">Rozbalit menu katalogu</span>
+                <span aria-hidden="true">▶</span>
+              </button>
+            </div>
+            <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
+          </li>
+          <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
+          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
+          <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
+          <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+
+  <main id="main">
+    <div>
+      <section class="main-content glossary-entry">
+        <a class="glossary-back" href="../slovnicek.html">&larr; Zpět na Slovníček</a>
+        <h2>Umělá inteligence</h2>
+        <p class="glossary-alt-name">English: Artificial Intelligence</p>
+        <p class="glossary-definition">Soubor metod a systémů, které napodobují nebo rozšiřují schopnosti lidské inteligence prostřednictvím
+          algoritmů, modelů a dat.</p>
+        <span class="glossary-tag">základní pojem</span>
+        <section class="glossary-section">
+          <h3>Co pojem znamená</h3>
+          <p>Umělá inteligence (AI) zahrnuje širokou škálu přístupů od jednodušších pravidlových systémů až po složité neuronové
+            sítě. Cílem je, aby systém samostatně vykonával úkoly, které běžně vyžadují lidské uvažování, vnímání nebo rozhodování.
+            Patří sem rozpoznávání obrazů, porozumění textu, předpovídání trendů i komunikace s lidmi.</p>
+          <p>V praxi veřejné správy AI pomáhá zrychlit rutinní operace, vyhledávat důležité informace v dokumentech nebo
+            analyzovat velké objemy dat, které by jinak bylo nemožné procházet ručně. Správná implementace vyžaduje kvalitní data,
+            transparentnost algoritmů a zapojení lidského dohledu.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Vysvětlení pro úředníky</h3>
+          <p>AI není jedna konkrétní technologie, ale soubor nástrojů. Úřady by měly posoudit, jaký problém řeší a zda AI skutečně
+            přináší přidanou hodnotu. Důležité je nastavit pravidla pro práci s daty, popsat rozhodovací logiku systému a určit,
+            kdo je za provoz a výsledky zodpovědný.</p>
+          <p>Před nasazením systému je vhodné připravit metodiku kontroly výsledků a zajistit, aby měli zaměstnanci potřebnou
+            gramotnost k interpretaci výstupů. Transparentní komunikace směrem k občanům zvyšuje důvěru a snižuje obavy z
+            automatizace.</p>
+        </section>
+        <section class="glossary-section">
+          <h3>Příklad z praxe</h3>
+          <p>Úřad digitalizuje příchozí poštu a využívá AI k automatickému třídění dokumentů podle typu podání. Systém vyhledává
+            klíčové informace a doporučuje další kroky. Úředník díky tomu věnuje více času složitým případům a méně času
+            manuálnímu přeposílání dokumentů.</p>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div>
+      <div class="footer-contacts">
+        <div class="footer-block">
+          <a href="https://dia.gov.cz" class="footer-logo" target="_blank" rel="noopener noreferrer">
+            <img src="../logos/dia_logo.svg" alt="Digitální a informační agentura">
+          </a>
+          <p>Katalog spravuje Digitální a informační agentura.</p>
+        </div>
+        <section class="footer-block">
+          <h3>Informace</h3>
+          <p><a href="../podminky.html">Podmínky využití a ochrana osobních údajů</a></p>
+          <p><a href="https://www.dia.gov.cz/cs/prohlaseni-o-pristupnosti" target="_blank"
+              rel="noopener noreferrer">Prohlášení o přístupnosti</a></p>
+        </section>
+        <section class="footer-block">
+          <h3>Kontakty</h3>
+          <p><a href="mailto:kc@dia.gov.cz">kc@dia.gov.cz</a></p>
+          <ul class="footer-social">
+            <li><a href="https://www.facebook.com/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">Facebook</a></li>
+            <li><a href="https://www.instagram.com/agentura_dia/" target="_blank" rel="noreferrer nofollow">Instagram</a>
+            </li>
+            <li><a href="https://x.com/agentura_dia" target="_blank" rel="noreferrer nofollow">X</a></li>
+            <li><a href="https://www.youtube.com/@agentura_dia" target="_blank" rel="noreferrer nofollow">YouTube</a>
+            </li>
+            <li><a href="https://www.linkedin.com/company/digitalniainformacniagentura" target="_blank"
+                rel="noreferrer nofollow">LinkedIn</a></li>
+          </ul>
+        </section>
+      </div>
+      <section class="footer-project">
+        <h3>Portál využití AI ve veřejném sektoru vám přináší</h3>
+        <div>
+          <div class="footer-block logos">
+            <img src="../logos/EU_logo.png" alt="EU logo">
+            <img src="../logos/NPO_logo.png" alt="NPO logo">
+            <img src="../logos/ictu_logo.png" alt="ICTÚ logo">
+            <img src="../logos/dia_logo.svg" alt="DIA logo">
+          </div>
+          <div class="footer-block">
+            <p>Vytvořeno v rámci projektu ROPIM – Reforma pro optimalizaci, implementaci a metodické řízení
+              digitalizovaných služeb vč. jejich kapacitního plánování a komunikaci klientům veřejné správy,
+              financovaného Evropskou unií NextGeneration.</p>
+            <p>REG. Č.: CZ.31.5.0/0.0/.0./23_106/0008503</p>
+          </div>
+        </div>
+      </section>
+      <div class="footer-bottom">
+        <p>2025 © Digitální a informační agentura • Informace jsou poskytovány v souladu se zákonem č. 106/1999 Sb.</p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../script.js"></script>
+</body>
+
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1459,3 +1459,77 @@ table#table-overview tr>* {
 table#table-overview tr>*:first-child {
     width: 50%;
 }
+
+.glossary-table-wrapper {
+    margin-top: 1.5rem;
+    overflow-x: auto;
+}
+
+.glossary-table {
+    table-layout: auto;
+    min-width: 100%;
+}
+
+.glossary-table td:first-child {
+    width: clamp(14rem, 30%, 20rem);
+    font-weight: 600;
+}
+
+.glossary-table a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+.glossary-table a:hover,
+.glossary-table a:focus {
+    text-decoration: underline;
+}
+
+.glossary-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background-color: rgba(32, 115, 21, 0.1);
+    color: var(--primary);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.glossary-entry {
+    max-width: 900px;
+}
+
+.glossary-back {
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: center;
+    margin-bottom: 1rem;
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.glossary-back:hover,
+.glossary-back:focus {
+    text-decoration: underline;
+}
+
+.glossary-definition {
+    font-size: 1.1rem;
+    font-weight: 500;
+    margin-bottom: 0.75rem;
+}
+
+.glossary-alt-name {
+    color: #4f4f4f;
+    margin-top: 0;
+}
+
+.glossary-section {
+    margin-top: 2rem;
+}
+
+.glossary-section h3 {
+    margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- build the glossary landing page with a static table of preferred terms and tags
- add dedicated glossary entry pages with reusable structure and supporting styles
- capture glossary source content in `slovnicek.json` for future reference

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cdd78cdb6c832ca53b38188357c011