### PR TITLE
Adjust counter styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1031,9 +1031,18 @@ h3 {
 }
 
 .usecase-counter {
+    position: relative;
     margin: clamp(2.5rem, 6vw, 4rem) 0;
     padding: clamp(2.75rem, 7vw, 4.5rem) clamp(1.25rem, 5vw, 3rem);
+    background: none;
+}
+
+.usecase-counter::before {
+    content: "";
+    position: absolute;
+    inset: 0 calc(50% - 50vw);
     background: #f4f5f7;
+    z-index: -1;
 }
 
 .usecase-counter__inner {
@@ -1098,7 +1107,7 @@ h3 {
 .usecase-counter__number {
     position: relative;
     display: block;
-    font-size: clamp(2.4rem, 7vw, 4.5rem);
+    font-size: clamp(2rem, 5.5vw, 3.6rem);
     font-weight: 700;
     line-height: 1;
     color: var(--primary);
@@ -1153,7 +1162,7 @@ h3 {
     }
 
     .usecase-counter__number {
-        font-size: clamp(2.2rem, 12vw, 3.5rem);
+        font-size: clamp(1.8rem, 10vw, 3.1rem);
     }
 }
 


### PR DESCRIPTION
## Summary
- extend the use case counter background to span the full viewport width with a pseudo-element
- reduce the counter digit font sizing to better match the rest of the page typography

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ced95c9264832ca43b8b6c4c09296a