### PR TITLE
Refine use case counter styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1031,34 +1031,41 @@ h3 {
 }
 
 .usecase-counter {
-    margin: clamp(2.5rem, 6vw, 4rem) 0;
-    padding: clamp(2.75rem, 7vw, 4.5rem) clamp(1.25rem, 5vw, 3rem);
+    position: relative;
+    margin: clamp(2rem, 5vw, 3.5rem) 0;
+    padding: clamp(2.25rem, 6vw, 3.75rem) clamp(1.25rem, 5vw, 2.5rem);
     background: #f4f5f7;
+    box-shadow: 0 0 0 100vmax #f4f5f7;
+    clip-path: inset(0 -100vmax);
+    box-sizing: border-box;
+    isolation: isolate;
 }
 
 .usecase-counter__inner {
-    max-width: min(960px, 100%);
+    max-width: min(920px, 100%);
     margin: 0 auto;
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: clamp(1.25rem, 3vw, 1.75rem);
+    gap: clamp(1rem, 2.5vw, 1.5rem);
 }
 
 .usecase-counter__headline {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    flex-wrap: nowrap;
-    gap: clamp(0.75rem, 2.5vw, 1.5rem);
+    flex-wrap: wrap;
+    gap: clamp(0.6rem, 2vw, 1.25rem);
     margin: 0;
-    font-size: clamp(1.15rem, 1.5vw + 1rem, 2.05rem);
-    font-weight: 600;
-    color: rgba(24, 24, 24, 0.92);
+    font-size: clamp(1.05rem, 1.2vw + 0.95rem, 1.85rem);
+    font-weight: 500;
+    color: rgba(24, 24, 24, 0.88);
+    font-family: "Roboto", "Roboto Web", "Noto Sans", sans-serif;
 }
 
 .usecase-counter__headline-text {
-    white-space: nowrap;
+    white-space: normal;
+    text-wrap: balance;
 }
 
 .usecase-counter__number-wrapper {
@@ -1066,13 +1073,13 @@ h3 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: clamp(0.45rem, 1.5vw, 0.7rem) clamp(1.1rem, 4vw, 1.8rem);
-    border-radius: 16px;
-    background: linear-gradient(160deg, #ffffff, #f3f3f3 70%, #ffffff);
-    box-shadow: 0 24px 45px -30px rgba(22, 31, 38, 0.55), 0 14px 24px -24px rgba(22, 31, 38, 0.35);
-    border: 1px solid rgba(12, 24, 35, 0.08);
+    padding: clamp(0.35rem, 1.3vw, 0.6rem) clamp(0.85rem, 3vw, 1.4rem);
+    border-radius: 12px;
+    background: linear-gradient(160deg, #ffffff, #f6f6f6 70%, #ffffff);
+    box-shadow: 0 16px 36px -28px rgba(22, 31, 38, 0.5), 0 12px 20px -26px rgba(22, 31, 38, 0.28);
+    border: 1px solid rgba(12, 24, 35, 0.06);
     perspective: 1000px;
-    min-width: clamp(5ch, 8vw, 7ch);
+    min-width: clamp(4.75ch, 7vw, 6.5ch);
 }
 
 .usecase-counter__number-wrapper::before,
@@ -1098,13 +1105,15 @@ h3 {
 .usecase-counter__number {
     position: relative;
     display: block;
-    font-size: clamp(2.4rem, 7vw, 4.5rem);
-    font-weight: 700;
+    font-size: clamp(2.05rem, 6.5vw, 3.75rem);
+    font-weight: 600;
     line-height: 1;
     color: var(--primary);
-    text-shadow: 0 14px 30px rgba(31, 65, 42, 0.25);
+    text-shadow: 0 12px 26px rgba(31, 65, 42, 0.22);
     transform-origin: center;
     will-change: transform;
+    font-family: "Roboto", "Roboto Web", "Noto Sans", sans-serif;
+    font-variant-numeric: tabular-nums;
 }
 
 .usecase-counter__number-wrapper.is-flipping .usecase-counter__number {
@@ -1138,22 +1147,31 @@ h3 {
 .usecase-counter__note {
     margin: 0 auto;
     max-width: 42ch;
-    font-size: clamp(0.95rem, 0.8vw + 0.9rem, 1.1rem);
-    color: rgba(24, 24, 24, 0.7);
+    font-size: clamp(0.9rem, 0.7vw + 0.85rem, 1.05rem);
+    color: rgba(24, 24, 24, 0.68);
 }
 
 @media (max-width: 600px) {
     .usecase-counter {
-        padding-inline: clamp(1rem, 6vw, 1.75rem);
+        padding-inline: clamp(1rem, 6vw, 1.6rem);
+        padding-block: clamp(1.75rem, 8vw, 2.5rem);
     }
 
     .usecase-counter__headline {
-        gap: clamp(0.5rem, 3vw, 0.9rem);
-        font-size: clamp(1rem, 4vw + 0.6rem, 1.5rem);
+        gap: clamp(0.45rem, 4vw, 0.8rem);
+        font-size: clamp(0.95rem, 4vw + 0.55rem, 1.35rem);
+    }
+
+    .usecase-counter__headline-text {
+        flex: 1 1 100%;
     }
 
     .usecase-counter__number {
-        font-size: clamp(2.2rem, 12vw, 3.5rem);
+        font-size: clamp(1.9rem, 11vw, 3.05rem);
+    }
+
+    .usecase-counter__note {
+        font-size: clamp(0.9rem, 3vw + 0.7rem, 1rem);
     }
 }
 


### PR DESCRIPTION
## Summary
- shrink the use case counter spacing and typography for better proportion with the page
- allow the counter background color to span the full viewport width without affecting layout
- improve mobile wrapping and typographic styling of the counter text and number

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cedd75f728832c9891f2b40e1fc2c4