### PR TITLE
Adjust use case counter styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1030,46 +1030,52 @@ h3 {
     text-align: justify;
 }
 
+
 .usecase-counter {
     position: relative;
-    margin: 5rem auto;
-    padding: 45px;
+    margin: clamp(3rem, 9vw, 4.5rem) auto;
+    padding: clamp(2rem, 6vw, 2.75rem);
     background: none;
 }
 
 .usecase-counter::before {
     content: "";
     position: absolute;
-    inset: 0 calc(50% - 50vw);
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100vw;
+    height: 100%;
     background: #c5c5c5;
-    z-index: -1;
+    z-index: 0;
 }
 
 .usecase-counter__inner {
+    position: relative;
+    z-index: 1;
     max-width: min(960px, 100%);
     margin: 0 auto;
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: 50px;
+    gap: clamp(1.75rem, 4vw, 2.5rem);
 }
 
 .usecase-counter__headline {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    flex-wrap: nowrap;
-    /* gap: clamp(0.75rem, 2.5vw, 1.5rem); */
+    flex-wrap: wrap;
     margin: 0;
-    font-size: 38px;
-    gap: 1rem;
-    /* font-size: clamp(1.15rem, 1.5vw + 1rem, 2.05rem); */
+    gap: clamp(0.5rem, 2vw, 1rem);
+    font-size: clamp(1.4rem, 2vw + 1rem, 2.1rem);
     font-weight: 600;
     color: rgba(24, 24, 24, 0.92);
+    font-family: "Roboto", "Roboto Web", "Noto Sans", "Segoe UI", sans-serif;
 }
 
 .usecase-counter__headline-text {
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .usecase-counter__number-wrapper {
@@ -1077,13 +1083,13 @@ h3 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 12px 0px;
-    border-radius: 16px;
+    padding: 10px 14px;
+    border-radius: 14px;
     background: linear-gradient(160deg, #ffffff, #f3f3f3 70%, #ffffff);
-    box-shadow: 0 24px 45px -30px rgba(22, 31, 38, 0.55), 0 14px 24px -24px rgba(22, 31, 38, 0.35);
+    box-shadow: 0 18px 32px -28px rgba(22, 31, 38, 0.5), 0 10px 18px -20px rgba(22, 31, 38, 0.32);
     border: 1px solid rgba(12, 24, 35, 0.08);
     perspective: 1000px;
-    min-width: clamp(5ch, 8vw, 7ch);
+    min-width: clamp(4.5ch, 7vw, 6ch);
 }
 
 .usecase-counter__number-wrapper::before,
@@ -1109,13 +1115,14 @@ h3 {
 .usecase-counter__number {
     position: relative;
     display: block;
-    font-size: clamp(2.4rem, 7vw, 4.5rem);
-    font-weight: 700;
-    line-height: 1;
+    font-size: clamp(2rem, 6vw, 3.5rem);
+    font-weight: 600;
+    line-height: 1.05;
     color: var(--primary);
-    text-shadow: 0 14px 30px rgba(31, 65, 42, 0.25);
+    text-shadow: 0 10px 24px rgba(31, 65, 42, 0.25);
     transform-origin: center;
     will-change: transform;
+    font-family: "Roboto", "Roboto Web", "Noto Sans", "Segoe UI", sans-serif;
 }
 
 .usecase-counter__number-wrapper.is-flipping .usecase-counter__number {
@@ -1141,23 +1148,28 @@ h3 {
 
 .usecase-counter__note {
     margin: 0 auto;
-    max-width: 42ch;
-    font-size: 32px;
+    max-width: 36ch;
+    font-size: clamp(1.05rem, 1vw + 1rem, 1.35rem);
     color: var(--primary);
+    font-weight: 500;
+    font-family: "Roboto", "Roboto Web", "Noto Sans", "Segoe UI", sans-serif;
 }
 
 @media (max-width: 600px) {
     .usecase-counter {
-        padding-inline: clamp(1rem, 6vw, 1.75rem);
+        padding-inline: clamp(1.25rem, 6vw, 1.75rem);
     }
 
     .usecase-counter__headline {
-        gap: clamp(0.5rem, 3vw, 0.9rem);
-        font-size: clamp(1rem, 4vw + 0.6rem, 1.5rem);
+        font-size: clamp(1.1rem, 4vw + 0.6rem, 1.65rem);
     }
 
     .usecase-counter__number {
-        font-size: clamp(2.2rem, 12vw, 3.5rem);
+        font-size: clamp(2.1rem, 12vw, 3.1rem);
+    }
+
+    .usecase-counter__note {
+        font-size: clamp(1rem, 3.5vw, 1.2rem);
     }
 }
 


### PR DESCRIPTION
## Summary
- scale down the use case counter spacing and typography for better proportion on the page
- ensure the grey counter background spans the full viewport width and keep content above it
- allow counter text to wrap and refine fonts and responsive sizes for improved readability on mobile

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cee280a290832c8ba28f438742d9de