### PR TITLE
Vylepšení stylu počítadla use cases

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1030,46 +1030,53 @@ h3 {
     text-align: justify;
 }
 
+
 .usecase-counter {
     position: relative;
-    margin: 5rem auto;
-    padding: 45px;
+    margin: clamp(2.5rem, 8vw, 4rem) auto;
+    padding: clamp(2rem, 6vw, 3rem) clamp(1.5rem, 6vw, 3.5rem);
     background: none;
+    isolation: isolate;
+    overflow: hidden;
 }
 
 .usecase-counter::before {
     content: "";
     position: absolute;
-    inset: 0 calc(50% - 50vw);
+    top: 0;
+    left: 50%;
+    width: 100vw;
+    height: 100%;
+    transform: translateX(-50%);
     background: #c5c5c5;
     z-index: -1;
 }
 
 .usecase-counter__inner {
-    max-width: min(960px, 100%);
+    max-width: min(880px, 100%);
     margin: 0 auto;
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: 50px;
+    gap: clamp(1.75rem, 4vw, 2.5rem);
 }
 
 .usecase-counter__headline {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    flex-wrap: nowrap;
-    /* gap: clamp(0.75rem, 2.5vw, 1.5rem); */
+    flex-wrap: wrap;
     margin: 0;
-    font-size: 38px;
-    gap: 1rem;
-    /* font-size: clamp(1.15rem, 1.5vw + 1rem, 2.05rem); */
+    gap: clamp(0.65rem, 2.5vw, 1.25rem);
+    font-size: clamp(1.35rem, 2vw + 1rem, 2rem);
     font-weight: 600;
-    color: rgba(24, 24, 24, 0.92);
+    color: rgba(24, 24, 24, 0.9);
+    font-family: "Roboto Web", "Roboto", "Noto Sans", sans-serif;
+    text-wrap: balance;
 }
 
 .usecase-counter__headline-text {
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .usecase-counter__number-wrapper {
@@ -1077,13 +1084,13 @@ h3 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 12px 0px;
-    border-radius: 16px;
+    padding: 0.75rem 1.75rem;
+    border-radius: 14px;
     background: linear-gradient(160deg, #ffffff, #f3f3f3 70%, #ffffff);
-    box-shadow: 0 24px 45px -30px rgba(22, 31, 38, 0.55), 0 14px 24px -24px rgba(22, 31, 38, 0.35);
+    box-shadow: 0 18px 32px -28px rgba(22, 31, 38, 0.55), 0 10px 20px -20px rgba(22, 31, 38, 0.3);
     border: 1px solid rgba(12, 24, 35, 0.08);
     perspective: 1000px;
-    min-width: clamp(5ch, 8vw, 7ch);
+    min-width: clamp(5ch, 10vw, 6.5ch);
 }
 
 .usecase-counter__number-wrapper::before,
@@ -1109,13 +1116,16 @@ h3 {
 .usecase-counter__number {
     position: relative;
     display: block;
-    font-size: clamp(2.4rem, 7vw, 4.5rem);
+    font-size: clamp(2.1rem, 8vw, 3.6rem);
     font-weight: 700;
     line-height: 1;
     color: var(--primary);
-    text-shadow: 0 14px 30px rgba(31, 65, 42, 0.25);
+    text-shadow: 0 12px 26px rgba(31, 65, 42, 0.25);
     transform-origin: center;
     will-change: transform;
+    font-family: "Roboto Web", "Roboto", "Noto Sans", sans-serif;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.02em;
 }
 
 .usecase-counter__number-wrapper.is-flipping .usecase-counter__number {
@@ -1141,23 +1151,40 @@ h3 {
 
 .usecase-counter__note {
     margin: 0 auto;
-    max-width: 42ch;
-    font-size: 32px;
+    max-width: 48ch;
+    font-size: clamp(1.05rem, 1vw + 0.9rem, 1.35rem);
     color: var(--primary);
+    font-weight: 500;
+    font-family: "Roboto Web", "Roboto", "Noto Sans", sans-serif;
+    text-wrap: pretty;
 }
 
 @media (max-width: 600px) {
     .usecase-counter {
-        padding-inline: clamp(1rem, 6vw, 1.75rem);
+        padding: clamp(1.75rem, 8vw, 2.5rem) clamp(1rem, 7vw, 1.75rem);
     }
 
     .usecase-counter__headline {
-        gap: clamp(0.5rem, 3vw, 0.9rem);
-        font-size: clamp(1rem, 4vw + 0.6rem, 1.5rem);
+        gap: clamp(0.5rem, 4vw, 0.75rem);
+        font-size: clamp(1.1rem, 4vw + 0.6rem, 1.45rem);
+        text-align: center;
     }
 
     .usecase-counter__number {
-        font-size: clamp(2.2rem, 12vw, 3.5rem);
+        font-size: clamp(2rem, 14vw, 3.1rem);
+    }
+
+    .usecase-counter__number-wrapper {
+        padding: 0.65rem 1.25rem;
+    }
+
+    .usecase-counter__headline-text {
+        display: inline-flex;
+        text-align: center;
+    }
+
+    .usecase-counter__note {
+        font-size: clamp(1rem, 4.5vw, 1.2rem);
     }
 }
 


### PR DESCRIPTION
## Summary
- zmenšil jsem celkové proporce počítadla a sjednotil fonty pro přehlednější vzhled
- upravil jsem šedé pozadí tak, aby pokrývalo celou šířku obrazovky
- doplnil jsem responsivní chování, aby texty na mobilu nepřetékaly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cee280a290832c8ba28f438742d9de