### PR TITLE
Fix layout and links on vector database glossary page

### DIFF
--- a/slovnicek/vektorova-databaze.html
+++ b/slovnicek/vektorova-databaze.html
@@ -94,8 +94,8 @@
 
         <section class="highlight">
           <p>Vektorová databáze je specializovaný úložný systém pro ukládání a vyhledávání dat ve formě vektorových
-            reprezentací (embeddingů).
-            Každý objekt (např. text, obrázek, zvuk) je převeden na vektor čísel a spolu s metadaty uložen do databáze.
+            reprezentací (<a href="embedding.html">embeddingů</a>).
+            Každý objekt (např. text, obrázek, zvuk) je převeden na <a href="vektor.html">vektor</a> čísel a spolu s metadaty uložen do databáze.
             Základní funkcí je vyhledávání „nejbližších sousedů“ – tedy vektorů, které jsou nejpodobnější zadanému
             vektoru podle určité metriky podobnosti (např. kosinové). Vektorové databáze se používají k vyhledávání
             podobných textů, obrázků, videí či jiných nestrukturovaných dat podle jejich významu, nikoli jen podle shody
@@ -119,7 +119,7 @@
           <h3>Jak fungují vektorové databáze?</h3>
           <p>Pro jednoduchost si představme <strong>prostor pouze se 2 rozměry</strong>: <em>počet nohou</em> a
             <em>velikost těla</em>.
-            Každé zvíře je bod – vektor <code>[počet končetin, velikost tvora]</code>. Zvířata s podobnými vlastnostmi
+            Každé zvíře je bod – <a href="vektor.html">vektor</a> <code>[počet končetin, velikost tvora]</code>. Zvířata s podobnými vlastnostmi
             budou
             blízko u
             sebe.
@@ -170,7 +170,7 @@
           <pre><code>vec("strýc") = [12.4, 232.1, -323.7, 0.8, ... , 41.2]</code></pre>
 
           <p>Každá souřadnice sama o sobě není interpretovatelná člověkem. Pro nás je embedding
-            <em>černou skříňkou</em> – vidíme vstup (slovo, věta) a výstup (vektor), ale nemůžeme
+            <a href="black-box.html"><em>černou skříňkou</em></a> – vidíme vstup (slovo, věta) a výstup (vektor), ale nemůžeme
             přímo říct, co znamená „souřadnice č. 347“. Přesto tato skrytá reprezentace
             zachovává užitečné vztahy mezi pojmy.
           </p>
@@ -186,9 +186,9 @@
             („pes“ – „kočka“, „město“ – „vesnice“) se proto v embeddingovém prostoru ocitají
             blízko sebe, zatímco odlišná („pes“ – „letadlo“) leží daleko.</p>
 
-          <p>Embeddingy vycházejí z <strong>tokenů</strong>, tedy jednotek textu, které model dokáže zpracovat.
+          <p>Embeddingy vycházejí z <a href="token.html"><strong>tokenů</strong></a>, tedy jednotek textu, které model dokáže zpracovat.
             Token obvykle odpovídá slovu nebo části slova (např. „učit“, „-el“, „na“). Model přiřadí
-            embedding každému tokenu a z jejich kombinace pak vytvoří embedding celé věty, odstavce
+            embedding každému <a href="token.html">tokenu</a> a z jejich kombinace pak vytvoří embedding celé věty, odstavce
             nebo dokumentu. Díky tomu lze vyhledávat nejen jednotlivá slova, ale i celé texty podle
             jejich významu.</p>
 

--- a/styles.css
+++ b/styles.css
@@ -1760,6 +1760,33 @@ table#table-overview tr>*:first-child {
     margin-bottom: 2.5rem;
 }
 
+.glossary-entry .glossary-image {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: 1.5rem auto;
+    border-radius: 12px;
+}
+
+.glossary-entry .glossary-table thead th {
+    display: table-cell;
+    text-align: left;
+    vertical-align: bottom;
+    padding: 0.85rem 1.5rem;
+}
+
+.glossary-entry pre {
+    background: rgba(32, 115, 21, 0.08);
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+}
+
+.glossary-entry code {
+    color: var(--primary);
+    font-weight: 600;
+}
+
 .glossary-entry__back {
     border-top: 1px solid #e0e5eb;
     padding-top: 1.5rem;
@@ -1778,6 +1805,10 @@ table#table-overview tr>*:first-child {
     border-radius: 999px;
     box-shadow: 0 6px 16px rgba(32, 115, 21, 0.18);
     transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.glossary-entry__back a:visited {
+    color: #fff;
 }
 
 .glossary-entry__back a:hover,


### PR DESCRIPTION
## Summary
- ensure the vector database glossary image scales within the content card and restyle code blocks, table headers, and the back link state
- add cross-links to related glossary entries for embeddings, vectors, tokens, and the black box concept

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cef7c4b0b8832cb943b8a204d3c721