### PR TITLE
Adjust AI literacy grid responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2243,7 +2243,19 @@ table#table-overview tr>*:first-child {
 .ai-literacy-actions__grid {
     display: grid;
     gap: clamp(1rem, 2.5vw, 1.75rem);
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+    .ai-literacy-actions__grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (min-width: 1024px) {
+    .ai-literacy-actions__grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
 }
 
 .ai-literacy-card {


### PR DESCRIPTION
## Summary
- enforce fixed responsive breakpoints for the AI literacy cards to show 1/2/3 columns at mobile, tablet, and desktop widths

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0612069a0832c96cb7347a81f659f