### PR TITLE
Rename AI compliance section to AI a právo and update layout

### DIFF
--- a/ai-a-pravo.html
+++ b/ai-a-pravo.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI compliance – Katalog využití umělé inteligence ve veřejném sektoru</title>
+  <title>AI a právo – Katalog využití umělé inteligence ve veřejném sektoru</title>
   <link rel="icon" type="image/png" href="https://www.dia.gov.cz/favicon-96x96.png?v2" sizes="96x96">
   <link rel="icon" type="image/svg+xml" href="https://www.dia.gov.cz/favicon.svg?v2">
   <link rel="shortcut icon" href="https://www.dia.gov.cz/favicon.ico?v2">
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html" aria-current="page">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html" aria-current="page">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html" aria-current="page">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html" aria-current="page">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html">Přidat use case</a></li>
@@ -78,12 +78,12 @@
 
   <main id="main">
     <div>
-      <section class="main-content">
-        <h2>AI compliance</h2>
+      <section class="main-content ai-law-page">
+        <h2>AI a právo</h2>
         <p>
-          AI compliance označuje soulad využití umělé inteligence s právními předpisy, etickými principy a interními
-          pravidly organizace. Zaměřuje se na zajištění transparentnosti, ochrany dat, férovosti a odpovědnosti při
-          návrhu, zavádění i provozu AI řešení.
+          AI a právo (AI compliance) označuje soulad využití umělé inteligence s právními předpisy, etickými principy a
+          interními pravidly organizace. Zaměřuje se na zajištění transparentnosti, ochrany dat, férovosti a odpovědnosti
+          při návrhu, zavádění i provozu AI řešení.
         </p>
         <p>
           V praxi zahrnuje vyhodnocování rizik, nastavování kontrolních mechanismů, vedení dokumentace i pravidelný
@@ -101,7 +101,7 @@
           <h3 id="serialy-nadpis">Seriály, které připravujeme</h3>
           <p>Na průsečíku práva a technologií spouštíme dva dlouhodobé seriály. Články budeme zveřejňovat postupně.</p>
 
-          <div class="grid-2">
+          <div class="serials-grid">
             <section class="card">
               <h4>AI a právo (populárně-naučné)</h4>
               <ol>
@@ -145,7 +145,7 @@
 
         <hr>
 
-        <section aria-labelledby="zdroje-nadpis">
+        <section aria-labelledby="zdroje-nadpis" class="resources-section">
           <h3 id="zdroje-nadpis">Užitečné zdroje a předpisy</h3>
 
           <div class="grid-3">
@@ -198,15 +198,15 @@
             </section>
           </div>
 
-          <details class="note" aria-label="Poznámka ke standardům">
-            <summary>Standardy a metodiky (doporučení)</summary>
+          <div class="resources-note" aria-label="Poznámka ke standardům">
+            <h4>Standardy a metodiky (doporučení)</h4>
             <ul>
               <li><a href="https://www.iso.org/standard/42001" target="_blank" rel="noopener noreferrer">ISO/IEC
                   42001:2023 – Systémy řízení AI (AIMS)</a></li>
               <li><a href="https://www.cencenelec.eu/areas-of-work/cen-cenelec-topics/artificial-intelligence/"
                   target="_blank" rel="noopener noreferrer">CEN/CENELEC JTC 21 – standardizace pro AI</a></li>
             </ul>
-          </details>
+          </div>
         </section>
       </section>
     </div>

--- a/ai-gramotnost.html
+++ b/ai-gramotnost.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html" aria-current="page">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html" aria-current="page">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html">Přidat use case</a></li>
@@ -122,7 +122,7 @@
               <p class="ai-literacy-card__motto">Osvojte si terminologii</p>
               <p class="ai-literacy-card__title">Slovníček</p>
             </a>
-            <a class="ai-literacy-card" href="ai-compliance.html">
+            <a class="ai-literacy-card" href="ai-a-pravo.html">
               <div class="ai-literacy-card__icon" aria-hidden="true">
                 <svg viewBox="0 0 64 64" role="img" focusable="false">
                   <path
@@ -151,7 +151,7 @@
               <p class="ai-literacy-card__motto">Pište lepší prompty</p>
               <p class="ai-literacy-card__title">Příručka prompt inženýrství</p>
             </a>
-            <a class="ai-literacy-card" href="ai-compliance.html">
+            <a class="ai-literacy-card" href="ai-a-pravo.html">
               <div class="ai-literacy-card__icon" aria-hidden="true">
                 <svg viewBox="0 0 64 64" role="img" focusable="false">
                   <rect x="12" y="10" width="40" height="44" rx="6" fill="#e8f3eb" />
@@ -162,7 +162,7 @@
                 </svg>
               </div>
               <p class="ai-literacy-card__motto">Znáte regulaci AI?</p>
-              <p class="ai-literacy-card__title">AI compliance</p>
+              <p class="ai-literacy-card__title">AI a právo</p>
             </a>
             <a class="ai-literacy-card" href="project.html">
               <div class="ai-literacy-card__icon" aria-hidden="true">

--- a/clanky.html
+++ b/clanky.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html" aria-current="page">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html" aria-current="page">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html">Přidat use case</a></li>

--- a/clanky/fyzicka-pravnicka-a-elektronicka-osoba.html
+++ b/clanky/fyzicka-pravnicka-a-elektronicka-osoba.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html" aria-current="page">Články</a></li>
         <li><a href="../slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html" aria-current="page">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/clanky/materialni-prameny-ai-prava.html
+++ b/clanky/materialni-prameny-ai-prava.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html" aria-current="page">Články</a></li>
         <li><a href="../slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html" aria-current="page">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html">Přidat use case</a></li>

--- a/podminky.html
+++ b/podminky.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html">Přidat use case</a></li>

--- a/project.html
+++ b/project.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html" aria-current="page">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html">Přidat use case</a></li>

--- a/prompt-inzenyrstvi.html
+++ b/prompt-inzenyrstvi.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html" aria-current="page">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>

--- a/slovnicek.html
+++ b/slovnicek.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html">Přidat use case</a></li>

--- a/slovnicek/ai-act.html
+++ b/slovnicek/ai-act.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/ai-gramotnost.html
+++ b/slovnicek/ai-gramotnost.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/algoritmus.html
+++ b/slovnicek/algoritmus.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/automatizace.html
+++ b/slovnicek/automatizace.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/bias.html
+++ b/slovnicek/bias.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/black-box.html
+++ b/slovnicek/black-box.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/captcha.html
+++ b/slovnicek/captcha.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/chatbot.html
+++ b/slovnicek/chatbot.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/digitalni-asistent.html
+++ b/slovnicek/digitalni-asistent.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/distributor.html
+++ b/slovnicek/distributor.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/dovozce.html
+++ b/slovnicek/dovozce.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/embedding.html
+++ b/slovnicek/embedding.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/evropsky-urad-pro-umelou-inteligenci.html
+++ b/slovnicek/evropsky-urad-pro-umelou-inteligenci.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/expertni-system.html
+++ b/slovnicek/expertni-system.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/explainable-ai.html
+++ b/slovnicek/explainable-ai.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/generative-ai.html
+++ b/slovnicek/generative-ai.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/halucinace.html
+++ b/slovnicek/halucinace.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/hluboke-uceni.html
+++ b/slovnicek/hluboke-uceni.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/inteligentni-agent.html
+++ b/slovnicek/inteligentni-agent.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/kavovy-test.html
+++ b/slovnicek/kavovy-test.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/large-language-model.html
+++ b/slovnicek/large-language-model.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/large-multimodal-model.html
+++ b/slovnicek/large-multimodal-model.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/natural-language-processing.html
+++ b/slovnicek/natural-language-processing.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/neuronova-sit.html
+++ b/slovnicek/neuronova-sit.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/pocitacove-videni.html
+++ b/slovnicek/pocitacove-videni.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/poskytovatel.html
+++ b/slovnicek/poskytovatel.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/prompt-inzenyrstvi.html
+++ b/slovnicek/prompt-inzenyrstvi.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/prompt.html
+++ b/slovnicek/prompt.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/rag.html
+++ b/slovnicek/rag.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/regulacni-sandbox.html
+++ b/slovnicek/regulacni-sandbox.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/strojove-uceni.html
+++ b/slovnicek/strojove-uceni.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/system-umele-inteligence.html
+++ b/slovnicek/system-umele-inteligence.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/testovaci-data.html
+++ b/slovnicek/testovaci-data.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/token.html
+++ b/slovnicek/token.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/trenovaci-data.html
+++ b/slovnicek/trenovaci-data.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/turinguv-stroj.html
+++ b/slovnicek/turinguv-stroj.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/uceni-bez-ucitele.html
+++ b/slovnicek/uceni-bez-ucitele.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/uceni-s-ucitelem.html
+++ b/slovnicek/uceni-s-ucitelem.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/umela-inteligence.html
+++ b/slovnicek/umela-inteligence.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/use-case.html
+++ b/slovnicek/use-case.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/validacni-prompt.html
+++ b/slovnicek/validacni-prompt.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/vektor.html
+++ b/slovnicek/vektor.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/vektorova-databaze.html
+++ b/slovnicek/vektorova-databaze.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/slovnicek/zavadejici-subjekt.html
+++ b/slovnicek/zavadejici-subjekt.html
@@ -35,7 +35,7 @@
       <ul class="main-nav__list">
         <li><a href="../project.html">Katalog</a></li>
         <li><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="../ai-compliance.html">AI compliance</a></li>
+        <li><a href="../ai-a-pravo.html">AI a právo</a></li>
         <li><a href="../prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="../clanky.html">Články</a></li>
         <li><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
@@ -64,7 +64,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="../ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="../ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="../ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="../clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="../slovnicek.html" aria-current="page">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="../wiki.html">Přidat use case</a></li>

--- a/styles.css
+++ b/styles.css
@@ -1031,6 +1031,92 @@ h3 {
     text-align: justify;
 }
 
+/* ===== AI a právo page ===== */
+.ai-law-page {
+    display: grid;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.ai-law-page .serials-grid {
+    display: grid;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+    .ai-law-page .serials-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.ai-law-page .serials-grid .card {
+    background: #ffffff;
+    border-radius: 16px;
+    padding: clamp(1.5rem, 4vw, 2.25rem);
+    box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.12);
+}
+
+.ai-law-page .serials-grid h4 {
+    margin-top: 0;
+}
+
+.ai-law-page .serials-grid ol {
+    padding-left: 1.25rem;
+    margin: 0;
+    display: grid;
+    gap: 0.35rem;
+}
+
+.ai-law-page .resources-section {
+    background: #ffffff;
+    border: 1px solid rgba(32, 115, 21, 0.15);
+    border-radius: 20px;
+    padding: clamp(1.75rem, 4vw, 2.5rem);
+    box-shadow: 0 10px 32px -18px rgba(0, 0, 0, 0.18);
+}
+
+.ai-law-page .resources-section .grid-3 {
+    display: grid;
+    gap: clamp(1.25rem, 3vw, 2rem);
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+    .ai-law-page .resources-section .grid-3 {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+}
+
+.ai-law-page .resources-section .card {
+    background: rgba(54, 133, 55, 0.06);
+    border-radius: 14px;
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.ai-law-page .resources-section h4 {
+    margin-top: 0;
+}
+
+.ai-law-page .resources-section ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.ai-law-page .resources-note {
+    margin-top: clamp(1.5rem, 4vw, 2rem);
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+    border-radius: 14px;
+    background: rgba(32, 115, 21, 0.08);
+    border: 1px solid rgba(32, 115, 21, 0.12);
+}
+
+.ai-law-page .resources-note h4 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+}
+
 .usecase-counter {
     position: relative;
     isolation: isolate;

--- a/wiki.html
+++ b/wiki.html
@@ -36,7 +36,7 @@
       <ul class="main-nav__list">
         <li><a href="project.html">Katalog</a></li>
         <li><a href="ai-gramotnost.html">AI gramotnost</a></li>
-        <li><a href="ai-compliance.html">AI compliance</a></li>
+        <li><a href="ai-a-pravo.html">AI a právo</a></li>
         <li><a href="prompt-inzenyrstvi.html">Prompt inženýrství</a></li>
         <li><a href="clanky.html">Články</a></li>
         <li><a href="slovnicek.html">Slovníček</a></li>
@@ -67,7 +67,7 @@
             <ul id="mobile-catalog-list" class="mobile-menu__submenu" hidden></ul>
           </li>
           <li class="mobile-menu__item"><a href="ai-gramotnost.html">AI gramotnost</a></li>
-          <li class="mobile-menu__item"><a href="ai-compliance.html">AI compliance</a></li>
+          <li class="mobile-menu__item"><a href="ai-a-pravo.html">AI a právo</a></li>
           <li class="mobile-menu__item"><a href="clanky.html">Články</a></li>
           <li class="mobile-menu__item"><a href="slovnicek.html">Slovníček</a></li>
           <li class="mobile-menu__item"><a href="wiki.html" aria-current="page">Přidat use case</a></li>


### PR DESCRIPTION
## Summary
- rename the AI compliance page, navigation labels and related links to **AI a právo**
- refresh the AI a právo page with a two-column desktop layout for the serials and a bordered resources block without the accordion
- add page-specific styling to support the new layout and card presentation

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d0621f2478832cbcb9f941d4975d50