### PR TITLE
Use relative HTML links

### DIFF
--- a/ai-a-pravo.html
+++ b/ai-a-pravo.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>
@@ -110,11 +110,11 @@
               <p>V populárně-naučném cyklu "AI a právo" vám postupně představíme klíčové právní aspekty
                 umělé inteligence. Budeme se věnovat praktickým i zajímavým tématům, která sovuisí s regulací AI.</p>
               <ol>
-                <li><a href="/clanky/materialni-prameny-ai-prava.html">Materiální prameny AI práva</a></li>
+                <li><a href="clanky/materialni-prameny-ai-prava.html">Materiální prameny AI práva</a></li>
                 <li>Formální prameny AI práva</li>
                 <li>AI právo jako samostatné právní odvětví?</li>
                 <li>Základní principy AI práva</li>
-                <li><a href="/clanky/fyzicka-pravnicka-a-elektronicka-osoba.html"">Fyzická, právnická a elektronická osoba?</a></li>
+                <li><a href="clanky/fyzicka-pravnicka-a-elektronicka-osoba.html"">Fyzická, právnická a elektronická osoba?</a></li>
                 <li>Akt o umělé inteligenci (AI Act)</li>
                 <li>AI a ochrana soukromí</li>
                 <li>Autonomní rozhodování</li>

--- a/ai-gramotnost.html
+++ b/ai-gramotnost.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/clanky.html
+++ b/clanky.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>
@@ -89,7 +89,7 @@
 
         <div class="articles-grid">
           <article class="article-card">
-            <a class="article-card__link" href="/slovnicek/vektorova-databaze.html">
+            <a class="article-card__link" href="slovnicek/vektorova-databaze.html">
               <div class="article-card__image-wrapper">
                 <img src="images/vector-database-2.png" alt="Ilustrační vizualizace vektorové databáze"
                   class="article-card__image" loading="lazy">
@@ -128,7 +128,7 @@
           </article>
 
           <article class="article-card">
-            <a class="article-card__link" href="/slovnicek/strojove-uceni.html">
+            <a class="article-card__link" href="slovnicek/strojove-uceni.html">
               <div class="article-card__image-wrapper">
                 <img src="images/strojove-uceni.png" alt="Grafické ztvárnění strojového učení"
                   class="article-card__image" loading="lazy">

--- a/clanky/fyzicka-pravnicka-a-elektronicka-osoba.html
+++ b/clanky/fyzicka-pravnicka-a-elektronicka-osoba.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/clanky/materialni-prameny-ai-prava.html
+++ b/clanky/materialni-prameny-ai-prava.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/podminky.html
+++ b/podminky.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/project.html
+++ b/project.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/prompt-inzenyrstvi.html
+++ b/prompt-inzenyrstvi.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>
@@ -83,8 +83,8 @@
       <section class="main-content">
         <h2>Příručka prompt inženýrství</h2>
         <p>
-          <a href="/slovnicek/prompt-inzenyrstvi.html">Prompt inženýrství</a> je dovednost vytváření efektivních zadání
-          (<a href="/slovnicek/prompt.html">promptů</a>) pro <a href="slovnicek/generative-ai.html">generativní
+          <a href="slovnicek/prompt-inzenyrstvi.html">Prompt inženýrství</a> je dovednost vytváření efektivních zadání
+          (<a href="slovnicek/prompt.html">promptů</a>) pro <a href="slovnicek/generative-ai.html">generativní
             modely umělé inteligence</a>, jako jsou <a href="slovnicek/large-language-model.html">velké jazykové
             modely</a> (např. Grok, Perplexity či Copilot) nebo modely pro generování obrázků
           (např. DALL·E či MidJourney). Cílem prompt inženýrství je navrhnout taková zadání, která povedou k požadovaným
@@ -92,14 +92,14 @@
           kvalitním výstupům od AI systémů.
         </p>
         <p>
-          Dobře navržený <a href="/slovnicek/prompt.html">prompt</a> může výrazně ovlivnit kvalitu, relevanci
-          a užitečnost odpovědí generovaných AI. <a href="/slovnicek/prompt-inzenyrstvi.html">Prompt inženýrství</a>
+          Dobře navržený <a href="slovnicek/prompt.html">prompt</a> může výrazně ovlivnit kvalitu, relevanci
+          a užitečnost odpovědí generovaných AI. <a href="slovnicek/prompt-inzenyrstvi.html">Prompt inženýrství</a>
           zahrnuje různé techniky, jako je
           specifikace kontextu, použití příkladů, kladení otevřen
           ých otázek a iterativní ladění promptů na základě zpětné vazby.
         </p>
         <p>
-          V kontextu veřejné správy může <a href="/slovnicek/prompt-inzenyrstvi.html">prompt inženýrství</a> pomoci
+          V kontextu veřejné správy může <a href="slovnicek/prompt-inzenyrstvi.html">prompt inženýrství</a> pomoci
           úředníkům a dalším pracovníkům efektivněji využívat
           AI nástroje pro
           zpracování dokumentů, analýzu dat, tvorbu textů a další úkoly, čímž se zvyšuje produktivita a kvalita služeb

--- a/slovnicek.html
+++ b/slovnicek.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/ai-act.html
+++ b/slovnicek/ai-act.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/ai-gramotnost.html
+++ b/slovnicek/ai-gramotnost.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/algoritmus.html
+++ b/slovnicek/algoritmus.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/automatizace.html
+++ b/slovnicek/automatizace.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/bias.html
+++ b/slovnicek/bias.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/black-box.html
+++ b/slovnicek/black-box.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/captcha.html
+++ b/slovnicek/captcha.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/chatbot.html
+++ b/slovnicek/chatbot.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/digitalni-asistent.html
+++ b/slovnicek/digitalni-asistent.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/distributor.html
+++ b/slovnicek/distributor.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/dovozce.html
+++ b/slovnicek/dovozce.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/embedding.html
+++ b/slovnicek/embedding.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/evropsky-urad-pro-umelou-inteligenci.html
+++ b/slovnicek/evropsky-urad-pro-umelou-inteligenci.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/expertni-system.html
+++ b/slovnicek/expertni-system.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/explainable-ai.html
+++ b/slovnicek/explainable-ai.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/generative-ai.html
+++ b/slovnicek/generative-ai.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/halucinace.html
+++ b/slovnicek/halucinace.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/hluboke-uceni.html
+++ b/slovnicek/hluboke-uceni.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/inteligentni-agent.html
+++ b/slovnicek/inteligentni-agent.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/kavovy-test.html
+++ b/slovnicek/kavovy-test.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/large-language-model.html
+++ b/slovnicek/large-language-model.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/large-multimodal-model.html
+++ b/slovnicek/large-multimodal-model.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/natural-language-processing.html
+++ b/slovnicek/natural-language-processing.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/neuronova-sit.html
+++ b/slovnicek/neuronova-sit.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/pocitacove-videni.html
+++ b/slovnicek/pocitacove-videni.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/poskytovatel.html
+++ b/slovnicek/poskytovatel.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/prompt-inzenyrstvi.html
+++ b/slovnicek/prompt-inzenyrstvi.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/prompt.html
+++ b/slovnicek/prompt.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/rag.html
+++ b/slovnicek/rag.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/regulacni-sandbox.html
+++ b/slovnicek/regulacni-sandbox.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/strojove-uceni.html
+++ b/slovnicek/strojove-uceni.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/system-umele-inteligence.html
+++ b/slovnicek/system-umele-inteligence.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/testovaci-data.html
+++ b/slovnicek/testovaci-data.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/token.html
+++ b/slovnicek/token.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/trenovaci-data.html
+++ b/slovnicek/trenovaci-data.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/turinguv-stroj.html
+++ b/slovnicek/turinguv-stroj.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/uceni-bez-ucitele.html
+++ b/slovnicek/uceni-bez-ucitele.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/uceni-s-ucitelem.html
+++ b/slovnicek/uceni-s-ucitelem.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/umela-inteligence.html
+++ b/slovnicek/umela-inteligence.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/use-case.html
+++ b/slovnicek/use-case.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/validacni-prompt.html
+++ b/slovnicek/validacni-prompt.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/vektor.html
+++ b/slovnicek/vektor.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/vektorova-databaze.html
+++ b/slovnicek/vektorova-databaze.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/slovnicek/zavadejici-subjekt.html
+++ b/slovnicek/zavadejici-subjekt.html
@@ -24,7 +24,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="../index.html">
           <img src="../logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>

--- a/wiki.html
+++ b/wiki.html
@@ -25,7 +25,7 @@
         </svg>
       </button>
       <h1>
-        <a href="/">
+        <a href="index.html">
           <img src="logos/katalog_AI.svg" alt="DIA: Katalog využití AI ve veřejném sektoru">
         </a>
       </h1>


### PR DESCRIPTION
## Summary
- replace absolute HTML anchors pointing to the site root with paths relative to each page
- ensure links from nested sections such as slovnicek and clanky point back to index.html via ../index.html
- update root-level pages to refer to dictionary entries with relative paths instead of absolute ones

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d068813c7c832ca2947df376a00932